### PR TITLE
Support general boundary conditions in FlucaFD

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,5 +1,15 @@
 # Testing Conventions for Fluca
 
+## Test Philosophy
+
+Tests validate **internal algorithms directly** — not end-to-end numerical results.
+
+- **No SNES or TS in tests.** Solving a nonlinear or time-dependent system requires assembling operators, iterating a solver, and checking convergence — too many moving parts to isolate a bug in one component.
+- **Construct inputs analytically.** Set up a Vec or DM with known values, call the function under test, and compare the output against analytically known results.
+- **One component per test.** Each test exercises a single operator, transform, or data structure. If you need a solver to get a meaningful input, the test is at the wrong abstraction level — test the solver's components separately.
+- **Minimal setup.** If the test body needs more than ~30 lines before the assertion, reconsider the scope.
+- **Print deterministic values only.** Golden output is byte-exact, so never print solver residuals, iteration counts, or errors between a computed result and an exact solution — these vary across platforms, PETSc versions, and floating-point rounding. Print things that are determined entirely by the algorithm logic: structured field values at fixed indices, norms of analytically constructed vectors, or integer metadata.
+
 This project uses a **golden-output testing system** — not googletest. Tests are C executables that print results to stdout, compared against expected output files.
 
 ## Test File Structure

--- a/.claude/skills/add-test/SKILL.md
+++ b/.claude/skills/add-test/SKILL.md
@@ -89,6 +89,8 @@ Examples from the codebase: `first_deriv`, `second_deriv_left_bc_dirichlet`, `al
 
 ## Checklist
 
+- [ ] Test validates an internal algorithm directly — no SNES or TS solve required
+- [ ] Inputs are constructed analytically; expected outputs are known without running a solver
 - [ ] `/*TEST*/` block has `suffix` and `args`
 - [ ] Source added to `TEST_SRCS` in CMakeLists.txt
 - [ ] Golden output captured from actual run (never hand-written)

--- a/.claude/skills/petsc-conventions/SKILL.md
+++ b/.claude/skills/petsc-conventions/SKILL.md
@@ -11,6 +11,7 @@ This project follows PETSc style. All C code must conform to these rules.
 
 - Pure **C** (not C++). Intersection of C99, C++11, MSVC v1900+.
 - No variable-length arrays. No `assert.h` (use `PetscAssert()`). No `register`. No `rand()`.
+- **Never** use `(void)param;` casts to suppress unused-parameter warnings. Leave unused parameters as-is; the compiler warnings are suppressed project-wide via build flags.
 
 ## Naming
 
@@ -98,6 +99,7 @@ The number is the 1-based argument position.
 - Group variables of the same type on the same or adjacent lines.
 - Pointers of different arity are different types (separate lines).
 - Arrays of different size are different types.
+- Don't declare pointers and non-pointers in a single line. Same for arrays and non-arrays.
 
 ## Memory Management
 
@@ -190,3 +192,5 @@ PetscCall(FlucaFDDestroy(&fd));   /* Destroy takes pointer-to-pointer */
 - [ ] Locals at block (scope) top, blank line before `PetscFunctionBegin`, no blank line before `PetscFunctionReturn`
 - [ ] `_Internal`, `_Private`, or class/type name suffix on all non-public functions
 - [ ] Functions that may raise an error (via `PetscCall`, `SETERRQ`, `PetscCheck`) must return `PetscErrorCode`
+- [ ] No braces for single-statement `if`/`else`/`for`
+- [ ] No trailing zeros after decimal point

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,10 @@ fluca/
 - Branch names must use a prefix: `feature/`, `refactor/`, `test/`, `doc/`, etc
 - When committing, only include source code files (`.c`, `.h`), build files (`CMakeLists.txt`), and test output files (`.out`). Never include documentation, `.claude/` files, or other non-source files unless explicitly requested.
 
-## Agent Code Modification Requirement
+## Agent Requirements
 
-Any agent that modifies code in this project **must** verify its changes against the `petsc-conventions` skill. When spawning such agents, include the skill content in the agent's prompt so it can self-check before returning results.
+- Any agent that modifies code in this project **must** verify its changes against the `petsc-conventions` skill. When spawning such agents, tell them to read `.claude/skills/petsc-conventions/SKILL.md` so they can self-check before returning results.
+- Any agent that adds tests **must** follow the `add-test` skill workflow. When spawning such agents, tell them to read `.claude/skills/add-test/SKILL.md` so they handle source generation, CMakeLists.txt registration, golden output capture, and ctest verification correctly.
 
 ## Key Modules
 

--- a/fluca/include/fluca/private/flucafdimpl.h
+++ b/fluca/include/fluca/private/flucafdimpl.h
@@ -125,15 +125,15 @@ typedef struct {
   PetscScalar *alpha_plus_base;
   PetscScalar *alpha_minus_base;
 
-  /* Velocity field (face-centered, single component on left/down/back face) */
-  PetscInt             vel_c;
-  DM                   vel_dm;      /* original DMStag (from Vec) */
-  DM                   vel_da;      /* DMDA for local storage (1 DOF) */
-  Vec                  vel_local;   /* local vector on vel_da */
-  VecScatter           vel_scatter; /* global DMStag vel -> local DMDA vel */
-  const PetscScalar   *arr_vel_1d;
-  const PetscScalar  **arr_vel_2d;
-  const PetscScalar ***arr_vel_3d;
+  /* Mass flux field (face-centered, single component on left/down/back face) */
+  PetscInt             mf_c;
+  DM                   mf_dm;      /* original DMStag (from Vec) */
+  DM                   mf_da;      /* DMDA for local storage (1 DOF) */
+  Vec                  mf_local;   /* local vector on mf_da */
+  VecScatter           mf_scatter; /* global DMStag mf -> local DMDA mf */
+  const PetscScalar   *arr_mf_1d;
+  const PetscScalar  **arr_mf_2d;
+  const PetscScalar ***arr_mf_3d;
 
   /* Current solution field (element-centered, single component) */
   DM                   phi_dm;      /* original DMStag (from Vec) */

--- a/fluca/include/fluca/private/flucafdimpl.h
+++ b/fluca/include/fluca/private/flucafdimpl.h
@@ -161,6 +161,8 @@ FLUCA_INTERN PetscErrorCode FlucaFDRemoveZeroStencilPoints_Internal(PetscInt *, 
 FLUCA_INTERN PetscErrorCode FlucaFDResolveScaleRefs_Internal(PetscInt, FlucaFDStencilPoint[]);
 FLUCA_INTERN PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt, FlucaFDStencilPoint[]);
 
+FLUCA_INTERN PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD, PetscInt, PetscInt, PetscInt, PetscInt, PetscScalar *);
+
 FLUCA_INTERN PetscErrorCode FlucaFDTermLinkCreate_Internal(FlucaFDTermLink *);
 FLUCA_INTERN PetscErrorCode FlucaFDTermLinkDuplicate_Internal(FlucaFDTermLink, FlucaFDTermLink *);
 FLUCA_INTERN PetscErrorCode FlucaFDTermLinkAppend_Internal(FlucaFDTermLink *, FlucaFDTermLink);

--- a/fluca/include/fluca/private/flucafdimpl.h
+++ b/fluca/include/fluca/private/flucafdimpl.h
@@ -5,6 +5,7 @@
 #include <petscdmstag.h>
 
 #define FLUCAFD_MAX_DIM          3
+#define FLUCAFD_MAX_COMPONENT    8
 #define FLUCAFD_MAX_STENCIL_SIZE 32
 #define FLUCAFD_ZERO_PIVOT_TOL   1e-14
 #define FLUCAFD_COEFF_ATOL       1e-10
@@ -41,7 +42,7 @@ struct _p_FlucaFD {
   PetscInt                 input_c;
   DMStagStencilLocation    output_loc;
   PetscInt                 output_c;
-  FlucaFDBoundaryCondition bcs[2 * FLUCAFD_MAX_DIM];
+  FlucaFDBoundaryCondition bcs[FLUCAFD_MAX_COMPONENT][2 * FLUCAFD_MAX_DIM];
 
   /* Data ----------------------------------------------------------------- */
   DM                  dm;
@@ -161,7 +162,7 @@ FLUCA_INTERN PetscErrorCode FlucaFDRemoveZeroStencilPoints_Internal(PetscInt *, 
 FLUCA_INTERN PetscErrorCode FlucaFDResolveScaleRefs_Internal(PetscInt, FlucaFDStencilPoint[]);
 FLUCA_INTERN PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt, FlucaFDStencilPoint[]);
 
-FLUCA_INTERN PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD, PetscInt, PetscInt, PetscInt, PetscInt, PetscScalar *);
+FLUCA_INTERN PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD, PetscInt, PetscInt, PetscInt, PetscInt, PetscInt, PetscScalar *);
 
 FLUCA_INTERN PetscErrorCode FlucaFDTermLinkCreate_Internal(FlucaFDTermLink *);
 FLUCA_INTERN PetscErrorCode FlucaFDTermLinkDuplicate_Internal(FlucaFDTermLink, FlucaFDTermLink *);

--- a/fluca/include/flucafd.h
+++ b/fluca/include/flucafd.h
@@ -83,7 +83,7 @@ typedef struct {
   FlucaFDLimiterFn *limiter;
   PetscScalar      *alpha_plus;
   PetscScalar      *alpha_minus;
-  const void       *arr_vel;
+  const void       *arr_mf;
   const void       *arr_phi;
   FlucaFD           fd_grad; /* gradient operator (element -> face) */
 } FlucaFDTVDRef;
@@ -152,7 +152,7 @@ FLUCA_EXTERN PetscFunctionList FlucaFDLimiterList;
 FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDCreate(DM, FlucaFDDirection, PetscInt, PetscInt, FlucaFD *);
 FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDSetDirection(FlucaFD, FlucaFDDirection);
 FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDSetLimiter(FlucaFD, const char *);
-FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDSetVelocity(FlucaFD, Vec, PetscInt);
+FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDSetMassFlux(FlucaFD, Vec, PetscInt);
 FLUCA_EXTERN PetscErrorCode FlucaFDSecondOrderTVDSetCurrentSolution(FlucaFD, Vec);
 
 FLUCA_EXTERN PetscFunctionList FlucaFDList;

--- a/fluca/include/flucafd.h
+++ b/fluca/include/flucafd.h
@@ -34,9 +34,13 @@ typedef enum {
 } FlucaFDBoundaryConditionType;
 FLUCA_EXTERN const char *FlucaFDBoundaryConditionTypes[];
 
+typedef PetscErrorCode (*FlucaFDBCValueFn)(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value);
+
 typedef struct {
   FlucaFDBoundaryConditionType type;
-  PetscScalar                  value; /* for Dirichlet/Neumann boundary conditions */
+  PetscScalar                  value;  /* constant value (used when fn == NULL) */
+  FlucaFDBCValueFn             fn;     /* function-based value (NULL = use constant) */
+  void                        *fn_ctx; /* user context for fn */
 } FlucaFDBoundaryCondition;
 
 /* Stencil point types */
@@ -71,18 +75,17 @@ typedef enum {
    for the internal arrays to remain valid. Stencil points with ntvds > 0
    must not be stored beyond the current call frame. */
 typedef struct {
-  FlucaFDTVDRefRole               role;    /* PREV or NEXT */
-  PetscInt                        i, j, k; /* face position where TVD is evaluated */
-  FlucaFDDirection                dir;
-  PetscInt                        N_dir;        /* domain size in TVD direction */
-  PetscBool                       periodic_dir; /* periodicity in TVD direction */
-  FlucaFDLimiterFn               *limiter;
-  PetscScalar                    *alpha_plus;
-  PetscScalar                    *alpha_minus;
-  const void                     *arr_vel;
-  const void                     *arr_phi;
-  FlucaFD                         fd_grad; /* gradient operator (element -> face) */
-  const FlucaFDBoundaryCondition *bcs;
+  FlucaFDTVDRefRole role;    /* PREV or NEXT */
+  PetscInt          i, j, k; /* face position where TVD is evaluated */
+  FlucaFDDirection  dir;
+  PetscInt          N_dir;        /* domain size in TVD direction */
+  PetscBool         periodic_dir; /* periodicity in TVD direction */
+  FlucaFDLimiterFn *limiter;
+  PetscScalar      *alpha_plus;
+  PetscScalar      *alpha_minus;
+  const void       *arr_vel;
+  const void       *arr_phi;
+  FlucaFD           fd_grad; /* gradient operator (element -> face) */
 } FlucaFDTVDRef;
 
 typedef struct {

--- a/fluca/include/flucafd.h
+++ b/fluca/include/flucafd.h
@@ -112,8 +112,8 @@ FLUCA_EXTERN PetscErrorCode FlucaFDViewFromOptions(FlucaFD, PetscObject, const c
 FLUCA_EXTERN PetscErrorCode FlucaFDSetDM(FlucaFD, DM);
 FLUCA_EXTERN PetscErrorCode FlucaFDSetInputLocation(FlucaFD, DMStagStencilLocation, PetscInt);
 FLUCA_EXTERN PetscErrorCode FlucaFDSetOutputLocation(FlucaFD, DMStagStencilLocation, PetscInt);
-FLUCA_EXTERN PetscErrorCode FlucaFDSetBoundaryConditions(FlucaFD, const FlucaFDBoundaryCondition[]);
-FLUCA_EXTERN PetscErrorCode FlucaFDGetBoundaryConditions(FlucaFD, FlucaFDBoundaryCondition[]);
+FLUCA_EXTERN PetscErrorCode FlucaFDSetBoundaryConditions(FlucaFD, PetscInt, const FlucaFDBoundaryCondition[]);
+FLUCA_EXTERN PetscErrorCode FlucaFDGetBoundaryConditions(FlucaFD, PetscInt, FlucaFDBoundaryCondition[]);
 FLUCA_EXTERN PetscErrorCode FlucaFDSetFromOptions(FlucaFD);
 FLUCA_EXTERN PetscErrorCode FlucaFDSetOptionsPrefix(FlucaFD, const char[]);
 FLUCA_EXTERN PetscErrorCode FlucaFDAppendOptionsPrefix(FlucaFD, const char[]);

--- a/fluca/src/fd/impls/secondordertvd/secondordertvd.c
+++ b/fluca/src/fd/impls/secondordertvd/secondordertvd.c
@@ -196,7 +196,6 @@ static PetscErrorCode FlucaFDGetStencilRaw_SecondOrderTVD(FlucaFD fd, PetscInt i
   points[0].tvds[0].arr_vel      = arr_vel;
   points[0].tvds[0].arr_phi      = arr_phi;
   points[0].tvds[0].fd_grad      = tvd->fd_grad;
-  points[0].tvds[0].bcs          = fd->bcs;
 
   points[1].type                 = FLUCAFD_STENCIL_GRID;
   points[1].loc                  = fd->input_loc;
@@ -221,7 +220,6 @@ static PetscErrorCode FlucaFDGetStencilRaw_SecondOrderTVD(FlucaFD fd, PetscInt i
   points[1].tvds[0].arr_vel      = arr_vel;
   points[1].tvds[0].arr_phi      = arr_phi;
   points[1].tvds[0].fd_grad      = tvd->fd_grad;
-  points[1].tvds[0].bcs          = fd->bcs;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/fluca/src/fd/impls/secondordertvd/secondordertvd.c
+++ b/fluca/src/fd/impls/secondordertvd/secondordertvd.c
@@ -150,7 +150,7 @@ static PetscErrorCode FlucaFDSetUp_SecondOrderTVD(FlucaFD fd)
 static PetscErrorCode FlucaFDGetStencilRaw_SecondOrderTVD(FlucaFD fd, PetscInt i, PetscInt j, PetscInt k, PetscInt *npoints, FlucaFDStencilPoint points[])
 {
   FlucaFD_SecondOrderTVD *tvd     = (FlucaFD_SecondOrderTVD *)fd->data;
-  const void             *arr_vel = (fd->dim == 1) ? (const void *)tvd->arr_vel_1d : (fd->dim == 2) ? (const void *)tvd->arr_vel_2d : (const void *)tvd->arr_vel_3d;
+  const void             *arr_mf  = (fd->dim == 1) ? (const void *)tvd->arr_mf_1d : (fd->dim == 2) ? (const void *)tvd->arr_mf_2d : (const void *)tvd->arr_mf_3d;
   const void             *arr_phi = (fd->dim == 1) ? (const void *)tvd->arr_phi_1d : (fd->dim == 2) ? (const void *)tvd->arr_phi_2d : (const void *)tvd->arr_phi_3d;
   PetscInt                idx;
 
@@ -193,7 +193,7 @@ static PetscErrorCode FlucaFDGetStencilRaw_SecondOrderTVD(FlucaFD fd, PetscInt i
   points[0].tvds[0].limiter      = tvd->limiter;
   points[0].tvds[0].alpha_plus   = tvd->alpha_plus;
   points[0].tvds[0].alpha_minus  = tvd->alpha_minus;
-  points[0].tvds[0].arr_vel      = arr_vel;
+  points[0].tvds[0].arr_mf       = arr_mf;
   points[0].tvds[0].arr_phi      = arr_phi;
   points[0].tvds[0].fd_grad      = tvd->fd_grad;
 
@@ -217,7 +217,7 @@ static PetscErrorCode FlucaFDGetStencilRaw_SecondOrderTVD(FlucaFD fd, PetscInt i
   points[1].tvds[0].limiter      = tvd->limiter;
   points[1].tvds[0].alpha_plus   = tvd->alpha_plus;
   points[1].tvds[0].alpha_minus  = tvd->alpha_minus;
-  points[1].tvds[0].arr_vel      = arr_vel;
+  points[1].tvds[0].arr_mf       = arr_mf;
   points[1].tvds[0].arr_phi      = arr_phi;
   points[1].tvds[0].fd_grad      = tvd->fd_grad;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -233,24 +233,24 @@ static PetscErrorCode FlucaFDDestroy_SecondOrderTVD(FlucaFD fd)
   PetscCall(PetscFree(tvd->alpha_plus_base));
   PetscCall(PetscFree(tvd->alpha_minus_base));
 
-  if (tvd->vel_dm) {
+  if (tvd->mf_dm) {
     switch (fd->dim) {
     case 1:
-      PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_1d));
+      PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_1d));
       break;
     case 2:
-      PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_2d));
+      PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_2d));
       break;
     case 3:
-      PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_3d));
+      PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_3d));
       break;
     default:
       break;
     }
-    PetscCall(VecScatterDestroy(&tvd->vel_scatter));
-    PetscCall(VecDestroy(&tvd->vel_local));
-    PetscCall(DMDestroy(&tvd->vel_da));
-    PetscCall(DMDestroy(&tvd->vel_dm));
+    PetscCall(VecScatterDestroy(&tvd->mf_scatter));
+    PetscCall(VecDestroy(&tvd->mf_local));
+    PetscCall(DMDestroy(&tvd->mf_da));
+    PetscCall(DMDestroy(&tvd->mf_dm));
   }
 
   if (tvd->phi_dm) {
@@ -286,7 +286,7 @@ static PetscErrorCode FlucaFDView_SecondOrderTVD(FlucaFD fd, PetscViewer viewer)
   PetscCall(PetscObjectTypeCompare((PetscObject)viewer, PETSCVIEWERASCII, &isascii));
   if (isascii) {
     PetscCall(PetscViewerASCIIPrintf(viewer, "  Direction: %s\n", FlucaFDDirections[tvd->dir]));
-    PetscCall(PetscViewerASCIIPrintf(viewer, "  Velocity component: %" PetscInt_FMT "\n", tvd->vel_c));
+    PetscCall(PetscViewerASCIIPrintf(viewer, "  Mass flux component: %" PetscInt_FMT "\n", tvd->mf_c));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -305,14 +305,14 @@ PetscErrorCode FlucaFDCreate_SecondOrderTVD(FlucaFD fd)
   tvd->alpha_minus      = NULL;
   tvd->alpha_plus_base  = NULL;
   tvd->alpha_minus_base = NULL;
-  tvd->vel_c            = 0;
-  tvd->vel_dm           = NULL;
-  tvd->vel_da           = NULL;
-  tvd->vel_local        = NULL;
-  tvd->vel_scatter      = NULL;
-  tvd->arr_vel_1d       = NULL;
-  tvd->arr_vel_2d       = NULL;
-  tvd->arr_vel_3d       = NULL;
+  tvd->mf_c             = 0;
+  tvd->mf_dm            = NULL;
+  tvd->mf_da            = NULL;
+  tvd->mf_local         = NULL;
+  tvd->mf_scatter       = NULL;
+  tvd->arr_mf_1d        = NULL;
+  tvd->arr_mf_2d        = NULL;
+  tvd->arr_mf_3d        = NULL;
   tvd->phi_dm           = NULL;
   tvd->phi_da           = NULL;
   tvd->phi_local        = NULL;
@@ -385,66 +385,66 @@ PetscErrorCode FlucaFDSecondOrderTVDSetLimiter(FlucaFD fd, const char *name)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode FlucaFDSecondOrderTVDSetVelocity(FlucaFD fd, Vec vel, PetscInt vel_c)
+PetscErrorCode FlucaFDSecondOrderTVDSetMassFlux(FlucaFD fd, Vec mass_flux, PetscInt mf_c)
 {
   FlucaFD_SecondOrderTVD *tvd = (FlucaFD_SecondOrderTVD *)fd->data;
-  DM                      vel_dm;
+  DM                      mf_dm;
   PetscBool               isstag;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecificType(fd, FLUCAFD_CLASSID, 1, FLUCAFDSECONDORDERTVD);
-  PetscValidHeaderSpecific(vel, VEC_CLASSID, 2);
-  PetscCall(VecGetDM(vel, &vel_dm));
-  PetscCall(PetscObjectTypeCompare((PetscObject)vel_dm, DMSTAG, &isstag));
+  PetscValidHeaderSpecific(mass_flux, VEC_CLASSID, 2);
+  PetscCall(VecGetDM(mass_flux, &mf_dm));
+  PetscCall(PetscObjectTypeCompare((PetscObject)mf_dm, DMSTAG, &isstag));
   PetscCheck(isstag, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_WRONGSTATE, "Vector is not on DMStag");
 
   /* Recreate scatter if DM or component changed */
-  if (fd->setupcalled && (vel_dm != tvd->vel_dm || vel_c != tvd->vel_c)) {
-    if (tvd->vel_dm) {
+  if (fd->setupcalled && (mf_dm != tvd->mf_dm || mf_c != tvd->mf_c)) {
+    if (tvd->mf_dm) {
       switch (fd->dim) {
       case 1:
-        PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_1d));
+        PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_1d));
         break;
       case 2:
-        PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_2d));
+        PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_2d));
         break;
       case 3:
-        PetscCall(DMDAVecRestoreArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_3d));
+        PetscCall(DMDAVecRestoreArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_3d));
         break;
       default:
         break;
       }
     }
-    PetscCall(VecScatterDestroy(&tvd->vel_scatter));
-    PetscCall(VecDestroy(&tvd->vel_local));
-    PetscCall(DMDestroy(&tvd->vel_da));
-    PetscCall(DMDestroy(&tvd->vel_dm));
+    PetscCall(VecScatterDestroy(&tvd->mf_scatter));
+    PetscCall(VecDestroy(&tvd->mf_local));
+    PetscCall(DMDestroy(&tvd->mf_da));
+    PetscCall(DMDestroy(&tvd->mf_dm));
   }
 
-  tvd->vel_c = vel_c;
-  if (!tvd->vel_dm) {
-    tvd->vel_dm = vel_dm;
-    PetscCall(PetscObjectReference((PetscObject)tvd->vel_dm));
-    PetscCall(FlucaFDCreateDMStagToDAScatter_Internal(tvd->vel_dm, fd->dim, fd->output_loc, vel_c, vel, &tvd->vel_da, &tvd->vel_local, &tvd->vel_scatter));
+  tvd->mf_c = mf_c;
+  if (!tvd->mf_dm) {
+    tvd->mf_dm = mf_dm;
+    PetscCall(PetscObjectReference((PetscObject)tvd->mf_dm));
+    PetscCall(FlucaFDCreateDMStagToDAScatter_Internal(tvd->mf_dm, fd->dim, fd->output_loc, mf_c, mass_flux, &tvd->mf_da, &tvd->mf_local, &tvd->mf_scatter));
 
     /* Get array views on local DMDA vector (kept until destroy) */
     switch (fd->dim) {
     case 1:
-      PetscCall(DMDAVecGetArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_1d));
+      PetscCall(DMDAVecGetArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_1d));
       break;
     case 2:
-      PetscCall(DMDAVecGetArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_2d));
+      PetscCall(DMDAVecGetArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_2d));
       break;
     case 3:
-      PetscCall(DMDAVecGetArrayRead(tvd->vel_da, tvd->vel_local, &tvd->arr_vel_3d));
+      PetscCall(DMDAVecGetArrayRead(tvd->mf_da, tvd->mf_local, &tvd->arr_mf_3d));
       break;
     default:
       SETERRQ(PetscObjectComm((PetscObject)fd), PETSC_ERR_SUP, "Unsupported dim");
     }
   }
-  /* Scatter only the needed face velocity component from global to local */
-  PetscCall(VecScatterBegin(tvd->vel_scatter, vel, tvd->vel_local, INSERT_VALUES, SCATTER_FORWARD));
-  PetscCall(VecScatterEnd(tvd->vel_scatter, vel, tvd->vel_local, INSERT_VALUES, SCATTER_FORWARD));
+  /* Scatter only the needed face mass flux component from global to local */
+  PetscCall(VecScatterBegin(tvd->mf_scatter, mass_flux, tvd->mf_local, INSERT_VALUES, SCATTER_FORWARD));
+  PetscCall(VecScatterEnd(tvd->mf_scatter, mass_flux, tvd->mf_local, INSERT_VALUES, SCATTER_FORWARD));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/fluca/src/fd/impls/secondordertvd/secondordertvd.c
+++ b/fluca/src/fd/impls/secondordertvd/secondordertvd.c
@@ -76,7 +76,7 @@ static PetscErrorCode FlucaFDSetUp_SecondOrderTVD(FlucaFD fd)
 
   /* Create internal gradient operator for dphi/dx (element -> face) */
   PetscCall(FlucaFDDerivativeCreate(fd->dm, tvd->dir, 1, 1, fd->input_loc, fd->input_c, fd->output_loc, 0, &tvd->fd_grad));
-  PetscCall(FlucaFDSetBoundaryConditions(tvd->fd_grad, fd->bcs));
+  PetscCall(FlucaFDSetBoundaryConditions(tvd->fd_grad, fd->input_c, fd->bcs[fd->input_c]));
   PetscCall(FlucaFDSetUp(tvd->fd_grad));
 
   /*

--- a/fluca/src/fd/interface/fdapply.c
+++ b/fluca/src/fd/interface/fdapply.c
@@ -118,10 +118,13 @@ PetscErrorCode FlucaFDApply(FlucaFD fd, DM input_dm, DM output_dm, Vec x, Vec y)
           case FLUCAFD_STENCIL_CONSTANT:
             result += points[c].v;
             break;
-          case FLUCAFD_STENCIL_BOUNDARY:
-            PetscCheck(points[c].boundary_face >= 0 && points[c].boundary_face < 2 * FLUCAFD_MAX_DIM, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Invalid boundary face %" PetscInt_FMT " in stencil", points[c].boundary_face);
-            result += points[c].v * fd->bcs[points[c].boundary_face].value;
+          case FLUCAFD_STENCIL_BOUNDARY: {
+            PetscScalar bc_val;
+
+            PetscCall(FlucaFDEvaluateBCValue_Internal(fd, points[c].boundary_face, points[c].i, points[c].j, points[c].k, &bc_val));
+            result += points[c].v * bc_val;
             break;
+          }
           }
         }
 

--- a/fluca/src/fd/interface/fdapply.c
+++ b/fluca/src/fd/interface/fdapply.c
@@ -74,7 +74,7 @@ PetscErrorCode FlucaFDApply(FlucaFD fd, DM input_dm, DM output_dm, Vec x, Vec y)
   FlucaFDStencilPoint points[FLUCAFD_MAX_STENCIL_SIZE];
   PetscInt            npoints;
   PetscInt            ir, idx;
-  PetscScalar         result;
+  PetscScalar         result, bc_val;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(fd, FLUCAFD_CLASSID, 1);
@@ -118,13 +118,10 @@ PetscErrorCode FlucaFDApply(FlucaFD fd, DM input_dm, DM output_dm, Vec x, Vec y)
           case FLUCAFD_STENCIL_CONSTANT:
             result += points[c].v;
             break;
-          case FLUCAFD_STENCIL_BOUNDARY: {
-            PetscScalar bc_val;
-
-            PetscCall(FlucaFDEvaluateBCValue_Internal(fd, points[c].boundary_face, points[c].i, points[c].j, points[c].k, &bc_val));
+          case FLUCAFD_STENCIL_BOUNDARY:
+            PetscCall(FlucaFDEvaluateBCValue_Internal(fd, points[c].c, points[c].boundary_face, points[c].i, points[c].j, points[c].k, &bc_val));
             result += points[c].v * bc_val;
             break;
-          }
           }
         }
 

--- a/fluca/src/fd/interface/fdbasic.c
+++ b/fluca/src/fd/interface/fdbasic.c
@@ -12,7 +12,7 @@ const char *FlucaFDBoundaryConditionTypes[] = {"NONE", "DIRICHLET", "NEUMANN", "
 PetscErrorCode FlucaFDCreate(MPI_Comm comm, FlucaFD *fd)
 {
   FlucaFD  f;
-  PetscInt d;
+  PetscInt comp, d;
 
   PetscFunctionBegin;
   PetscAssertPointer(fd, 2);
@@ -24,11 +24,13 @@ PetscErrorCode FlucaFDCreate(MPI_Comm comm, FlucaFD *fd)
   f->output_c   = 0;
   f->output_loc = DMSTAG_ELEMENT;
   f->dm         = NULL;
-  for (d = 0; d < 2 * FLUCAFD_MAX_DIM; ++d) {
-    f->bcs[d].type   = FLUCAFD_BC_NONE;
-    f->bcs[d].value  = 0.;
-    f->bcs[d].fn     = NULL;
-    f->bcs[d].fn_ctx = NULL;
+  for (comp = 0; comp < FLUCAFD_MAX_COMPONENT; ++comp) {
+    for (d = 0; d < 2 * FLUCAFD_MAX_DIM; ++d) {
+      f->bcs[comp][d].type   = FLUCAFD_BC_NONE;
+      f->bcs[comp][d].value  = 0.;
+      f->bcs[comp][d].fn     = NULL;
+      f->bcs[comp][d].fn_ctx = NULL;
+    }
   }
   f->dim = PETSC_DETERMINE;
   for (d = 0; d < FLUCAFD_MAX_DIM; ++d) {
@@ -171,7 +173,7 @@ PetscErrorCode FlucaFDViewFromOptions(FlucaFD fd, PetscObject obj, const char na
 PetscErrorCode FlucaFDSetUp(FlucaFD fd)
 {
   PetscBool      isdmstag;
-  PetscInt       d;
+  PetscInt       comp, d;
   DMBoundaryType bt[FLUCAFD_MAX_DIM];
 
   PetscFunctionBegin;
@@ -192,11 +194,13 @@ PetscErrorCode FlucaFDSetUp(FlucaFD fd)
   PetscCall(DMStagGetStencilWidth(fd->dm, &fd->stencil_width));
 
   /* Clear stale BC entries beyond the actual dimension */
-  for (d = 2 * fd->dim; d < 2 * FLUCAFD_MAX_DIM; ++d) {
-    fd->bcs[d].type   = FLUCAFD_BC_NONE;
-    fd->bcs[d].value  = 0.;
-    fd->bcs[d].fn     = NULL;
-    fd->bcs[d].fn_ctx = NULL;
+  for (comp = 0; comp < FLUCAFD_MAX_COMPONENT; ++comp) {
+    for (d = 2 * fd->dim; d < 2 * FLUCAFD_MAX_DIM; ++d) {
+      fd->bcs[comp][d].type   = FLUCAFD_BC_NONE;
+      fd->bcs[comp][d].value  = 0.;
+      fd->bcs[comp][d].fn     = NULL;
+      fd->bcs[comp][d].fn_ctx = NULL;
+    }
   }
 
   /* Get coordinate arrays and slots directly from DMStag */

--- a/fluca/src/fd/interface/fdbasic.c
+++ b/fluca/src/fd/interface/fdbasic.c
@@ -25,8 +25,10 @@ PetscErrorCode FlucaFDCreate(MPI_Comm comm, FlucaFD *fd)
   f->output_loc = DMSTAG_ELEMENT;
   f->dm         = NULL;
   for (d = 0; d < 2 * FLUCAFD_MAX_DIM; ++d) {
-    f->bcs[d].type  = FLUCAFD_BC_NONE;
-    f->bcs[d].value = 0.;
+    f->bcs[d].type   = FLUCAFD_BC_NONE;
+    f->bcs[d].value  = 0.;
+    f->bcs[d].fn     = NULL;
+    f->bcs[d].fn_ctx = NULL;
   }
   f->dim = PETSC_DETERMINE;
   for (d = 0; d < FLUCAFD_MAX_DIM; ++d) {
@@ -188,6 +190,14 @@ PetscErrorCode FlucaFDSetUp(FlucaFD fd)
   PetscCall(DMStagGetIsFirstRank(fd->dm, &fd->is_first_rank[0], &fd->is_first_rank[1], &fd->is_first_rank[2]));
   PetscCall(DMStagGetIsLastRank(fd->dm, &fd->is_last_rank[0], &fd->is_last_rank[1], &fd->is_last_rank[2]));
   PetscCall(DMStagGetStencilWidth(fd->dm, &fd->stencil_width));
+
+  /* Clear stale BC entries beyond the actual dimension */
+  for (d = 2 * fd->dim; d < 2 * FLUCAFD_MAX_DIM; ++d) {
+    fd->bcs[d].type   = FLUCAFD_BC_NONE;
+    fd->bcs[d].value  = 0.;
+    fd->bcs[d].fn     = NULL;
+    fd->bcs[d].fn_ctx = NULL;
+  }
 
   /* Get coordinate arrays and slots directly from DMStag */
   PetscCall(DMStagGetProductCoordinateArraysRead(fd->dm, &fd->arr_coord[0], &fd->arr_coord[1], &fd->arr_coord[2]));

--- a/fluca/src/fd/interface/fdopts.c
+++ b/fluca/src/fd/interface/fdopts.c
@@ -17,6 +17,7 @@ PetscErrorCode FlucaFDSetInputLocation(FlucaFD fd, DMStagStencilLocation loc, Pe
   PetscFunctionBegin;
   PetscValidHeaderSpecific(fd, FLUCAFD_CLASSID, 1);
   PetscCall(FlucaFDValidateStencilLocation_Internal(loc));
+  PetscCheck(c >= 0 && c < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Input component %" PetscInt_FMT " out of range [0, %d)", c, FLUCAFD_MAX_COMPONENT);
   fd->input_loc = loc;
   fd->input_c   = c;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -27,38 +28,41 @@ PetscErrorCode FlucaFDSetOutputLocation(FlucaFD fd, DMStagStencilLocation loc, P
   PetscFunctionBegin;
   PetscValidHeaderSpecific(fd, FLUCAFD_CLASSID, 1);
   PetscCall(FlucaFDValidateStencilLocation_Internal(loc));
+  PetscCheck(c >= 0 && c < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Output component %" PetscInt_FMT " out of range [0, %d)", c, FLUCAFD_MAX_COMPONENT);
   fd->output_loc = loc;
   fd->output_c   = c;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode FlucaFDSetBoundaryConditions(FlucaFD fd, const FlucaFDBoundaryCondition bcs[])
+PetscErrorCode FlucaFDSetBoundaryConditions(FlucaFD fd, PetscInt component, const FlucaFDBoundaryCondition bcs[])
 {
   PetscInt dim, nb;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(fd, FLUCAFD_CLASSID, 1);
-  PetscAssertPointer(bcs, 2);
+  PetscAssertPointer(bcs, 3);
 
+  PetscCheck(component >= 0 && component < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "component %" PetscInt_FMT " out of range [0, %d)", component, FLUCAFD_MAX_COMPONENT);
   PetscCheck(fd->dm, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_WRONGSTATE, "Reference DM must be set before setting boundary conditions");
   PetscCall(DMGetDimension(fd->dm, &dim));
   nb = 2 * dim;
-  PetscCall(PetscArraycpy(fd->bcs, bcs, nb));
+  PetscCall(PetscArraycpy(fd->bcs[component], bcs, nb));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode FlucaFDGetBoundaryConditions(FlucaFD fd, FlucaFDBoundaryCondition bcs[])
+PetscErrorCode FlucaFDGetBoundaryConditions(FlucaFD fd, PetscInt component, FlucaFDBoundaryCondition bcs[])
 {
   PetscInt dim, nb;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(fd, FLUCAFD_CLASSID, 1);
-  PetscAssertPointer(bcs, 2);
+  PetscAssertPointer(bcs, 3);
 
+  PetscCheck(component >= 0 && component < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "component %" PetscInt_FMT " out of range [0, %d)", component, FLUCAFD_MAX_COMPONENT);
   PetscCheck(fd->dm, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_WRONGSTATE, "Reference DM must be set before getting boundary conditions");
   PetscCall(DMGetDimension(fd->dm, &dim));
   nb = 2 * dim;
-  PetscCall(PetscArraycpy(bcs, fd->bcs, nb));
+  PetscCall(PetscArraycpy(bcs, fd->bcs[component], nb));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -69,7 +73,7 @@ PetscErrorCode FlucaFDSetFromOptions(FlucaFD fd)
   char              opt[PETSC_MAX_OPTION_NAME];
   char              text[PETSC_MAX_PATH_LEN];
   PetscBool         flg;
-  PetscInt          dim, d;
+  PetscInt          dim, d, comp;
   DMBoundaryType    bt[3];
   const char *const boundary_names[] = {"left", "right", "down", "up", "back", "front"};
 
@@ -85,16 +89,20 @@ PetscErrorCode FlucaFDSetFromOptions(FlucaFD fd)
   else if (!((PetscObject)fd)->type_name) PetscCall(FlucaFDSetType(fd, default_type));
   PetscCall(PetscOptionsEnum("-flucafd_input_loc", "Input stencil location", "FlucaFDSetInputLocation", DMStagStencilLocations, (PetscEnum)fd->input_loc, (PetscEnum *)&fd->input_loc, NULL));
   PetscCall(PetscOptionsInt("-flucafd_input_c", "Input component", "FlucaFDSetInputLocation", fd->input_c, &fd->input_c, NULL));
+  PetscCheck(fd->input_c >= 0 && fd->input_c < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Input component %" PetscInt_FMT " out of range [0, %d)", fd->input_c, FLUCAFD_MAX_COMPONENT);
   PetscCall(PetscOptionsEnum("-flucafd_output_loc", "Output stencil location", "FlucaFDSetOutputLocation", DMStagStencilLocations, (PetscEnum)fd->output_loc, (PetscEnum *)&fd->output_loc, NULL));
   PetscCall(PetscOptionsInt("-flucafd_output_c", "Output component", "FlucaFDSetOutputLocation", fd->output_c, &fd->output_c, NULL));
+  PetscCheck(fd->output_c >= 0 && fd->output_c < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Output component %" PetscInt_FMT " out of range [0, %d)", fd->output_c, FLUCAFD_MAX_COMPONENT);
   PetscCheck(fd->dm, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_WRONGSTATE, "Reference DM not set. Call FlucaFDSetDM() first");
   PetscCall(DMGetDimension(fd->dm, &dim));
   PetscCall(DMStagGetBoundaryTypes(fd->dm, &bt[0], &bt[1], &bt[2]));
+  /* Per-component BC type option: -flucafd_<c>_<boundary>_bc_type (only for this operator's input_c) */
   for (d = 0; d < 2 * dim; ++d) {
-    if (bt[d / 2] == DM_BOUNDARY_PERIODIC) continue; /* Skip BC options for periodic directions */
-    PetscCall(PetscSNPrintf(opt, PETSC_MAX_OPTION_NAME, "-flucafd_%s_bc_type", boundary_names[d]));
-    PetscCall(PetscSNPrintf(text, PETSC_MAX_PATH_LEN, "Boundary condition type on the %s boundary", boundary_names[d]));
-    PetscCall(PetscOptionsEnum(opt, text, "FlucaFDSetBoundaryConditions", FlucaFDBoundaryConditionTypes, (PetscEnum)fd->bcs[d].type, (PetscEnum *)&fd->bcs[d].type, NULL));
+    if (bt[d / 2] == DM_BOUNDARY_PERIODIC) continue;
+    comp = fd->input_c;
+    PetscCall(PetscSNPrintf(opt, PETSC_MAX_OPTION_NAME, "-flucafd_%" PetscInt_FMT "_%s_bc_type", comp, boundary_names[d]));
+    PetscCall(PetscSNPrintf(text, PETSC_MAX_PATH_LEN, "BC type on the %s boundary for component %" PetscInt_FMT, boundary_names[d], comp));
+    PetscCall(PetscOptionsEnum(opt, text, "FlucaFDSetBoundaryConditions", FlucaFDBoundaryConditionTypes, (PetscEnum)fd->bcs[comp][d].type, (PetscEnum *)&fd->bcs[comp][d].type, NULL));
   }
   PetscTryTypeMethod(fd, setfromoptions, PetscOptionsObject);
   /* Process any options handlers added with PetscObjectAddOptionsHandler() */

--- a/fluca/src/fd/utils/fdutils.c
+++ b/fluca/src/fd/utils/fdutils.c
@@ -1,6 +1,64 @@
 #include <fluca/private/flucafdimpl.h>
 #include <petscdmda.h>
 
+PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD fd, PetscInt boundary_face, PetscInt i, PetscInt j, PetscInt k, PetscScalar *value)
+{
+  const FlucaFDBoundaryCondition *bc;
+
+  PetscFunctionBegin;
+  PetscCheck(boundary_face >= 0 && boundary_face < 2 * fd->dim, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "boundary_face %" PetscInt_FMT " out of range for %" PetscInt_FMT "D problem", boundary_face, fd->dim);
+  bc = &fd->bcs[boundary_face];
+  if (bc->fn) {
+    PetscReal x[FLUCAFD_MAX_DIM];
+    PetscInt  d, idx[FLUCAFD_MAX_DIM];
+    PetscInt  dir;
+
+    idx[0] = i;
+    idx[1] = j;
+    idx[2] = k;
+
+    /* Boundary face determines the direction (0=left/right, 1=down/up, 2=back/front) */
+    dir = boundary_face / 2;
+
+    /* For the boundary direction, the boundary index is 0 or N[dir]. Use slot_coord_prev
+       (face coordinate). For other directions, use element slot. */
+    for (d = 0; d < fd->dim; ++d) {
+      PetscInt  gxs, gxm, gxe, slot;
+      PetscBool use_face;
+
+      use_face = (d == dir);
+      slot     = use_face ? fd->slot_coord_prev : fd->slot_coord_elem;
+      PetscCall(FlucaFDGetGhostCorners_Internal(fd, d, use_face, &gxs, &gxm, &gxe));
+
+      /* Compute h_prev and h_next for extrapolation */
+      {
+        const PetscScalar **arr_coord = fd->arr_coord[d];
+        PetscScalar         h_prev, h_next, coord;
+        PetscInt            first_face_idx, last_face_idx;
+        PetscBool           periodic;
+        PetscInt            gxs_face, gxm_face, gxe_face;
+
+        periodic = fd->periodic[d];
+        PetscCall(FlucaFDGetGhostCorners_Internal(fd, d, PETSC_TRUE, &gxs_face, &gxm_face, &gxe_face));
+        first_face_idx = gxs_face;
+        last_face_idx  = gxs_face + gxm_face - ((fd->is_last_rank[d] && !periodic) ? 0 : 1);
+        h_prev         = arr_coord[first_face_idx + 1][fd->slot_coord_prev] - arr_coord[first_face_idx][fd->slot_coord_prev];
+        h_next         = arr_coord[last_face_idx][fd->slot_coord_prev] - arr_coord[last_face_idx - 1][fd->slot_coord_prev];
+
+        PetscCall(FlucaFDGetCoordinate_Internal(arr_coord, idx[d], slot, gxs, gxm + gxe, h_prev, h_next, &coord));
+        x[d] = PetscRealPart(coord);
+      }
+    }
+    /* Fill remaining dimensions with 0 */
+    for (d = fd->dim; d < FLUCAFD_MAX_DIM; ++d) x[d] = 0.;
+
+    PetscCall(bc->fn(fd->dim, x, bc->fn_ctx, value));
+  } else {
+    *value = bc->value;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 PetscErrorCode FlucaFDValidateOperand_Internal(FlucaFD parent, FlucaFD operand)
 {
   PetscBool compatible, set;
@@ -597,7 +655,7 @@ PetscErrorCode FlucaFDResolveScaleRefs_Internal(PetscInt npoints, FlucaFDStencil
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode EvaluateGradient_Private(FlucaFD fd_grad, PetscInt dim, PetscInt i, PetscInt j, PetscInt k, const void *arr_phi, const FlucaFDBoundaryCondition bcs[], PetscScalar *grad)
+static PetscErrorCode EvaluateGradient_Private(FlucaFD fd_grad, PetscInt dim, PetscInt i, PetscInt j, PetscInt k, const void *arr_phi, PetscScalar *grad)
 {
   FlucaFDStencilPoint grad_points[FLUCAFD_MAX_STENCIL_SIZE];
   PetscInt            ngrad, c;
@@ -622,9 +680,13 @@ static PetscErrorCode EvaluateGradient_Private(FlucaFD fd_grad, PetscInt dim, Pe
         SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "Unsupported dim");
       }
       break;
-    case FLUCAFD_STENCIL_BOUNDARY:
-      *grad += grad_points[c].v * bcs[grad_points[c].boundary_face].value;
+    case FLUCAFD_STENCIL_BOUNDARY: {
+      PetscScalar bc_val;
+
+      PetscCall(FlucaFDEvaluateBCValue_Internal(fd_grad, grad_points[c].boundary_face, grad_points[c].i, grad_points[c].j, grad_points[c].k, &bc_val));
+      *grad += grad_points[c].v * bc_val;
       break;
+    }
     case FLUCAFD_STENCIL_CONSTANT:
       SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "Unexpected constant in gradient stencil");
     }
@@ -708,8 +770,8 @@ PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt npoints, FlucaFDStencilPo
       k_d   = (ref->dir == FLUCAFD_Z) ? ref->k - 1 : ref->k;
     }
 
-    PetscCall(EvaluateGradient_Private(ref->fd_grad, ref->fd_grad->dim, i_fu, j_fu, k_fu, ref->arr_phi, ref->bcs, &grad_fu));
-    PetscCall(EvaluateGradient_Private(ref->fd_grad, ref->fd_grad->dim, ref->i, ref->j, ref->k, ref->arr_phi, ref->bcs, &grad_fc));
+    PetscCall(EvaluateGradient_Private(ref->fd_grad, ref->fd_grad->dim, i_fu, j_fu, k_fu, ref->arr_phi, &grad_fu));
+    PetscCall(EvaluateGradient_Private(ref->fd_grad, ref->fd_grad->dim, ref->i, ref->j, ref->k, ref->arr_phi, &grad_fc));
 
     r   = (PetscAbsScalar(grad_fc) > FLUCAFD_TVD_GRAD_TOL) ? grad_fu / grad_fc : 1.;
     psi = ref->limiter(r);

--- a/fluca/src/fd/utils/fdutils.c
+++ b/fluca/src/fd/utils/fdutils.c
@@ -719,7 +719,7 @@ PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt npoints, FlucaFDStencilPo
 {
   PetscInt             n;
   const FlucaFDTVDRef *ref;
-  PetscScalar          vel;
+  PetscScalar          mf;
   PetscInt             idx;
   PetscInt             i_fu, j_fu, k_fu;
 
@@ -732,7 +732,7 @@ PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt npoints, FlucaFDStencilPo
     if (points[n].ntvds != 1) continue;
     ref = &points[n].tvds[0];
 
-    PetscCall(ReadPhiValue_Private(ref->fd_grad->dim, ref->arr_vel, ref->i, ref->j, ref->k, &vel));
+    PetscCall(ReadPhiValue_Private(ref->fd_grad->dim, ref->arr_mf, ref->i, ref->j, ref->k, &mf));
 
     switch (ref->dir) {
     case FLUCAFD_X:
@@ -748,7 +748,7 @@ PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt npoints, FlucaFDStencilPo
       SETERRQ(PETSC_COMM_SELF, PETSC_ERR_SUP, "Unsupported TVD direction");
     }
 
-    if (vel >= 0) {
+    if (mf >= 0) {
       alpha = ref->alpha_plus[idx];
       i_fu  = (ref->dir == FLUCAFD_X) ? ref->i - 1 : ref->i;
       j_fu  = (ref->dir == FLUCAFD_Y) ? ref->j - 1 : ref->j;
@@ -778,7 +778,7 @@ PetscErrorCode FlucaFDResolveTVDRefs_Internal(PetscInt npoints, FlucaFDStencilPo
     r   = (PetscAbsScalar(grad_fc) > FLUCAFD_TVD_GRAD_TOL) ? grad_fu / grad_fc : 1.;
     psi = ref->limiter(r);
 
-    is_upwind = (vel >= 0 && ref->role == FLUCAFD_TVD_PREV) || (vel < 0 && ref->role == FLUCAFD_TVD_NEXT);
+    is_upwind = (mf >= 0 && ref->role == FLUCAFD_TVD_PREV) || (mf < 0 && ref->role == FLUCAFD_TVD_NEXT);
     if (is_upwind) {
       points[n].v *= 2.;
     } else {

--- a/fluca/src/fd/utils/fdutils.c
+++ b/fluca/src/fd/utils/fdutils.c
@@ -1,13 +1,14 @@
 #include <fluca/private/flucafdimpl.h>
 #include <petscdmda.h>
 
-PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD fd, PetscInt boundary_face, PetscInt i, PetscInt j, PetscInt k, PetscScalar *value)
+PetscErrorCode FlucaFDEvaluateBCValue_Internal(FlucaFD fd, PetscInt component, PetscInt boundary_face, PetscInt i, PetscInt j, PetscInt k, PetscScalar *value)
 {
   const FlucaFDBoundaryCondition *bc;
 
   PetscFunctionBegin;
+  PetscCheck(component >= 0 && component < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "component %" PetscInt_FMT " out of range [0, %d)", component, FLUCAFD_MAX_COMPONENT);
   PetscCheck(boundary_face >= 0 && boundary_face < 2 * fd->dim, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "boundary_face %" PetscInt_FMT " out of range for %" PetscInt_FMT "D problem", boundary_face, fd->dim);
-  bc = &fd->bcs[boundary_face];
+  bc = &fd->bcs[component][boundary_face];
   if (bc->fn) {
     PetscReal x[FLUCAFD_MAX_DIM];
     PetscInt  d, idx[FLUCAFD_MAX_DIM];
@@ -412,8 +413,9 @@ PetscErrorCode FlucaFDRemoveOffGridPoints_Internal(FlucaFD fd, PetscInt *npoints
 
       periodic = fd->periodic[off_dir];
 
-      if (is_low && fd->is_first_rank[off_dir] && !periodic) bc_type = fd->bcs[2 * off_dir].type;
-      else if (!is_low && fd->is_last_rank[off_dir] && !periodic) bc_type = fd->bcs[2 * off_dir + 1].type;
+      PetscCheck(off_point.c >= 0 && off_point.c < FLUCAFD_MAX_COMPONENT, PetscObjectComm((PetscObject)fd), PETSC_ERR_ARG_OUTOFRANGE, "Stencil point component %" PetscInt_FMT " out of range [0, %d)", off_point.c, FLUCAFD_MAX_COMPONENT);
+      if (is_low && fd->is_first_rank[off_dir] && !periodic) bc_type = fd->bcs[off_point.c][2 * off_dir].type;
+      else if (!is_low && fd->is_last_rank[off_dir] && !periodic) bc_type = fd->bcs[off_point.c][2 * off_dir + 1].type;
       else bc_type = FLUCAFD_BC_NONE;
 
       arr_coord = fd->arr_coord[off_dir];
@@ -683,7 +685,7 @@ static PetscErrorCode EvaluateGradient_Private(FlucaFD fd_grad, PetscInt dim, Pe
     case FLUCAFD_STENCIL_BOUNDARY: {
       PetscScalar bc_val;
 
-      PetscCall(FlucaFDEvaluateBCValue_Internal(fd_grad, grad_points[c].boundary_face, grad_points[c].i, grad_points[c].j, grad_points[c].k, &bc_val));
+      PetscCall(FlucaFDEvaluateBCValue_Internal(fd_grad, grad_points[c].c, grad_points[c].boundary_face, grad_points[c].i, grad_points[c].j, grad_points[c].k, &bc_val));
       *grad += grad_points[c].v * bc_val;
       break;
     }

--- a/fluca/tests/fd/CMakeLists.txt
+++ b/fluca/tests/fd/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SRCS
     ex4.c
     ex7.c
     ex8.c
+    ex9.c
 )
 
 foreach(test_src ${TEST_SRCS})

--- a/fluca/tests/fd/CMakeLists.txt
+++ b/fluca/tests/fd/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SRCS
     ex7.c
     ex8.c
     ex9.c
+    ex10.c
 )
 
 foreach(test_src ${TEST_SRCS})

--- a/fluca/tests/fd/ex1.c
+++ b/fluca/tests/fd/ex1.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
   test:
     suffix: second_deriv_left_bc_dirichlet
     nsize: 1
-    args: -flucafd_left_bc_type dirichlet -flucafd_deriv_order 2 -flucafd_accu_order 2 -i 0
+    args: -flucafd_0_left_bc_type dirichlet -flucafd_deriv_order 2 -flucafd_accu_order 2 -i 0
 
   test:
     suffix: second_deriv_right_bc_none
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
   test:
     suffix: second_deriv_right_bc_neumann
     nsize: 1
-    args: -flucafd_right_bc_type neumann -flucafd_deriv_order 2 -flucafd_accu_order 2 -i 7
+    args: -flucafd_0_right_bc_type neumann -flucafd_deriv_order 2 -flucafd_accu_order 2 -i 7
 
   test:
     suffix: second_deriv_refined
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
   test:
     suffix: first_deriv_input_loc_elem_output_loc_left_left_bc_neumann
     nsize: 1
-    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc element -flucafd_output_loc left -flucafd_left_bc_type neumann -i 0
+    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc element -flucafd_output_loc left -flucafd_0_left_bc_type neumann -i 0
 
   test:
     suffix: first_deriv_input_loc_elem_output_loc_left_left_bc_periodic
@@ -126,12 +126,12 @@ int main(int argc, char **argv)
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_left_bc_dirichlet
     nsize: 1
-    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_left_bc_type dirichlet -i 0
+    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_0_left_bc_type dirichlet -i 0
 
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_left_bc_neumann
     nsize: 1
-    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_left_bc_type neumann -i 0
+    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_0_left_bc_type neumann -i 0
 
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_left_bc_periodic
@@ -146,12 +146,12 @@ int main(int argc, char **argv)
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_right_bc_dirichlet
     nsize: 1
-    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_right_bc_type dirichlet -i 8
+    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_0_right_bc_type dirichlet -i 8
 
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_right_bc_neumann
     nsize: 1
-    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_right_bc_type neumann -i 8
+    args: -flucafd_deriv_order 1 -flucafd_accu_order 2 -flucafd_input_loc left -flucafd_output_loc left -flucafd_0_right_bc_type neumann -i 8
 
   test:
     suffix: first_deriv_input_loc_left_output_loc_left_right_bc_periodic

--- a/fluca/tests/fd/ex10.c
+++ b/fluca/tests/fd/ex10.c
@@ -1,0 +1,159 @@
+#include <flucafd.h>
+#include <flucasys.h>
+#include <petscdmstag.h>
+
+#include "fdtest.h"
+
+static const char help[] = "Test per-component boundary conditions in FlucaFDSum\n";
+
+/*
+  Input: 2 element DOFs on a 1D grid with DM_BOUNDARY_NONE.
+    Component 0: u(x) = x^2
+    Component 1: v(x) = sin(pi * x)
+
+  fd_a = d/dx on component 0, fd_b = d/dx on component 1.
+  fd_sum = fd_a + fd_b, with per-component BCs set on the sum:
+    Component 0: Dirichlet u(0)=0, u(1)=1
+    Component 1: Neumann   v'(0)=pi, v'(1)=-pi
+
+  We print stencils at boundary-adjacent indices and verify that
+  applying the sum matches applying each operand individually.
+*/
+
+static PetscErrorCode FillInputVector(DM dm, Vec u)
+{
+  Vec                 u_local;
+  PetscInt            x, m, i, slot_elem0, slot_elem1;
+  PetscScalar       **arr;
+  const PetscScalar **arr_coord;
+  PetscInt            slot_coord_elem;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMStagGetProductCoordinateArraysRead(dm, &arr_coord, NULL, NULL));
+  PetscCall(DMStagGetProductCoordinateLocationSlot(dm, DMSTAG_ELEMENT, &slot_coord_elem));
+  PetscCall(DMStagGetLocationSlot(dm, DMSTAG_ELEMENT, 0, &slot_elem0));
+  PetscCall(DMStagGetLocationSlot(dm, DMSTAG_ELEMENT, 1, &slot_elem1));
+  PetscCall(DMStagGetCorners(dm, &x, NULL, NULL, &m, NULL, NULL, NULL, NULL, NULL));
+
+  PetscCall(DMGetLocalVector(dm, &u_local));
+  PetscCall(VecZeroEntries(u_local));
+  PetscCall(DMStagVecGetArray(dm, u_local, &arr));
+  for (i = x; i < x + m; ++i) {
+    PetscReal xi       = PetscRealPart(arr_coord[i][slot_coord_elem]);
+    arr[i][slot_elem0] = xi * xi;
+    arr[i][slot_elem1] = PetscSinReal(PETSC_PI * xi);
+  }
+  PetscCall(DMStagVecRestoreArray(dm, u_local, &arr));
+  PetscCall(DMLocalToGlobal(dm, u_local, INSERT_VALUES, u));
+  PetscCall(DMRestoreLocalVector(dm, &u_local));
+  PetscCall(DMStagRestoreProductCoordinateArraysRead(dm, &arr_coord, NULL, NULL));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **argv)
+{
+  DM                       dm_in, dm_out;
+  FlucaFD                  fd_a, fd_b, fd_sum;
+  FlucaFD                  operands[2];
+  FlucaFDBoundaryCondition bcs_comp0[2] = {{0}}, bcs_comp1[2] = {{0}};
+  Vec                      u, y_sum, y_a, y_b;
+  PetscReal                norm_diff;
+  FlucaFDStencilPoint      points[64];
+  PetscInt                 npoints, M;
+
+  PetscCall(FlucaInitialize(&argc, &argv, NULL, help));
+
+  /* Input DM: 2 element DOFs (component 0 = u, component 1 = v) */
+  PetscCall(DMStagCreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, 8, 0, 2, DMSTAG_STENCIL_BOX, 1, NULL, &dm_in));
+  PetscCall(DMSetUp(dm_in));
+  PetscCall(DMStagSetUniformCoordinatesProduct(dm_in, 0., 1., 0., 0., 0., 0.));
+
+  /* Output DM: 1 element DOF */
+  PetscCall(DMStagCreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, 8, 0, 1, DMSTAG_STENCIL_BOX, 1, NULL, &dm_out));
+  PetscCall(DMSetUp(dm_out));
+  PetscCall(DMStagSetUniformCoordinatesProduct(dm_out, 0., 1., 0., 0., 0., 0.));
+
+  /* fd_a: d/dx on input component 0 -> output component 0 */
+  PetscCall(FlucaFDDerivativeCreate(dm_in, FLUCAFD_X, 1, 2, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_a));
+  /* fd_b: d/dx on input component 1 -> output component 0 */
+  PetscCall(FlucaFDDerivativeCreate(dm_in, FLUCAFD_X, 1, 2, DMSTAG_ELEMENT, 1, DMSTAG_ELEMENT, 0, &fd_b));
+
+  /* BCs for component 0 (u=x^2): Dirichlet u(0)=0, u(1)=1 */
+  bcs_comp0[0].type  = FLUCAFD_BC_DIRICHLET;
+  bcs_comp0[0].value = 0.;
+  bcs_comp0[1].type  = FLUCAFD_BC_DIRICHLET;
+  bcs_comp0[1].value = 1.;
+
+  /* BCs for component 1 (v=sin(pi*x)): Neumann v'(0)=pi, v'(1)=-pi */
+  bcs_comp1[0].type  = FLUCAFD_BC_NEUMANN;
+  bcs_comp1[0].value = PETSC_PI;
+  bcs_comp1[1].type  = FLUCAFD_BC_NEUMANN;
+  bcs_comp1[1].value = -PETSC_PI;
+
+  /* Set BCs on individual operators (for reference apply) */
+  PetscCall(FlucaFDSetBoundaryConditions(fd_a, 0, bcs_comp0));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_b, 1, bcs_comp1));
+  PetscCall(FlucaFDSetUp(fd_a));
+  PetscCall(FlucaFDSetUp(fd_b));
+
+  /* Create sum operator and set per-component BCs on root */
+  operands[0] = fd_a;
+  operands[1] = fd_b;
+  PetscCall(FlucaFDSumCreate(2, operands, &fd_sum));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_sum, 0, bcs_comp0));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_sum, 1, bcs_comp1));
+  PetscCall(FlucaFDSetUp(fd_sum));
+
+  /* Print stencils at boundary-adjacent indices */
+  PetscCall(DMStagGetGlobalSizes(dm_out, &M, NULL, NULL));
+
+  PetscCall(FlucaFDGetStencil(fd_sum, 0, 0, 0, &npoints, points));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Stencil at i=0 (left boundary):\n"));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "  npoints = %" PetscInt_FMT "\n", npoints));
+  PetscCall(PrintStencil(1, npoints, points));
+
+  PetscCall(FlucaFDGetStencil(fd_sum, M - 1, 0, 0, &npoints, points));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Stencil at i=%" PetscInt_FMT " (right boundary):\n", M - 1));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "  npoints = %" PetscInt_FMT "\n", npoints));
+  PetscCall(PrintStencil(1, npoints, points));
+
+  /* Apply sum operator */
+  PetscCall(DMCreateGlobalVector(dm_in, &u));
+  PetscCall(FillInputVector(dm_in, u));
+
+  PetscCall(DMCreateGlobalVector(dm_out, &y_sum));
+  PetscCall(FlucaFDApply(fd_sum, dm_in, dm_out, u, y_sum));
+
+  /* Apply individual operators and sum results manually */
+  PetscCall(DMCreateGlobalVector(dm_out, &y_a));
+  PetscCall(DMCreateGlobalVector(dm_out, &y_b));
+  PetscCall(FlucaFDApply(fd_a, dm_in, dm_out, u, y_a));
+  PetscCall(FlucaFDApply(fd_b, dm_in, dm_out, u, y_b));
+
+  /* y_sum should equal y_a + y_b */
+  PetscCall(VecAXPY(y_a, 1.0, y_b));
+  PetscCall(VecAXPY(y_sum, -1.0, y_a));
+  PetscCall(VecNorm(y_sum, NORM_INFINITY, &norm_diff));
+  PetscCheck(norm_diff < 1e-10, PETSC_COMM_WORLD, PETSC_ERR_PLIB, "||y_sum - (y_a + y_b)||_inf = %g exceeds tolerance", (double)norm_diff);
+
+  PetscCall(VecDestroy(&y_b));
+  PetscCall(VecDestroy(&y_a));
+  PetscCall(VecDestroy(&y_sum));
+  PetscCall(VecDestroy(&u));
+  PetscCall(FlucaFDDestroy(&fd_sum));
+  PetscCall(FlucaFDDestroy(&fd_b));
+  PetscCall(FlucaFDDestroy(&fd_a));
+  PetscCall(DMDestroy(&dm_out));
+  PetscCall(DMDestroy(&dm_in));
+
+  PetscCall(FlucaFinalize());
+}
+
+/*TEST
+
+  test:
+    suffix: per_component_bcs
+    nsize: 1
+    args:
+
+TEST*/

--- a/fluca/tests/fd/ex7.c
+++ b/fluca/tests/fd/ex7.c
@@ -13,10 +13,10 @@ int main(int argc, char **argv)
 {
   DM                  input_dm, output_dm;
   FlucaFD             fd_tvd;
-  Vec                 phi, vel;
+  Vec                 phi, mass_flux;
   PetscInt            M, x, m, nExtrax, i, npoints, idx, slot_elem, slot_face;
-  PetscScalar       **arr_phi, **arr_vel;
-  Vec                 phi_local, vel_local;
+  PetscScalar       **arr_phi, **arr_mass_flux;
+  Vec                 phi_local, mass_flux_local;
   const PetscScalar **arr_coord;
   PetscInt            slot_coord_elem;
   FlucaFDStencilPoint points[64];
@@ -48,15 +48,15 @@ int main(int argc, char **argv)
   PetscCall(DMLocalToGlobal(input_dm, phi_local, INSERT_VALUES, phi));
   PetscCall(DMRestoreLocalVector(input_dm, &phi_local));
 
-  /* Create and fill velocity vector (face-centered) with constant velocity */
-  PetscCall(DMCreateGlobalVector(output_dm, &vel));
-  PetscCall(DMGetLocalVector(output_dm, &vel_local));
-  PetscCall(VecZeroEntries(vel_local));
-  PetscCall(DMStagVecGetArray(output_dm, vel_local, &arr_vel));
-  for (i = x; i < x + m + nExtrax; ++i) arr_vel[i][slot_face] = 1.0;
-  PetscCall(DMStagVecRestoreArray(output_dm, vel_local, &arr_vel));
-  PetscCall(DMLocalToGlobal(output_dm, vel_local, INSERT_VALUES, vel));
-  PetscCall(DMRestoreLocalVector(output_dm, &vel_local));
+  /* Create and fill mass flux vector (face-centered) with constant value */
+  PetscCall(DMCreateGlobalVector(output_dm, &mass_flux));
+  PetscCall(DMGetLocalVector(output_dm, &mass_flux_local));
+  PetscCall(VecZeroEntries(mass_flux_local));
+  PetscCall(DMStagVecGetArray(output_dm, mass_flux_local, &arr_mass_flux));
+  for (i = x; i < x + m + nExtrax; ++i) arr_mass_flux[i][slot_face] = 1.0;
+  PetscCall(DMStagVecRestoreArray(output_dm, mass_flux_local, &arr_mass_flux));
+  PetscCall(DMLocalToGlobal(output_dm, mass_flux_local, INSERT_VALUES, mass_flux));
+  PetscCall(DMRestoreLocalVector(output_dm, &mass_flux_local));
 
   PetscCall(DMStagRestoreProductCoordinateArraysRead(input_dm, &arr_coord, NULL, NULL));
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
     PetscCall(FlucaFDSetBoundaryConditions(fd_tvd, 0, bcs));
   }
 
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(fd_tvd, vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(fd_tvd, mass_flux, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(fd_tvd, phi));
 
   PetscCall(DMStagGetGlobalSizes(output_dm, &M, NULL, NULL));
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
   PetscCall(PrintStencil(1, npoints, points));
 
   PetscCall(FlucaFDDestroy(&fd_tvd));
-  PetscCall(VecDestroy(&vel));
+  PetscCall(VecDestroy(&mass_flux));
   PetscCall(VecDestroy(&phi));
   PetscCall(DMDestroy(&output_dm));
   PetscCall(DMDestroy(&input_dm));

--- a/fluca/tests/fd/ex7.c
+++ b/fluca/tests/fd/ex7.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
     bcs[0].value = 0.;
     bcs[1].type  = FLUCAFD_BC_DIRICHLET;
     bcs[1].value = 1.;
-    PetscCall(FlucaFDSetBoundaryConditions(fd_tvd, bcs));
+    PetscCall(FlucaFDSetBoundaryConditions(fd_tvd, 0, bcs));
   }
   PetscCall(FlucaFDSetFromOptions(fd_tvd));
   PetscCall(FlucaFDSetUp(fd_tvd));
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   {
     FlucaFDBoundaryCondition bcs[2];
 
-    PetscCall(FlucaFDGetBoundaryConditions(fd_tvd, bcs));
+    PetscCall(FlucaFDGetBoundaryConditions(fd_tvd, 0, bcs));
     switch (bcs[0].type) {
     case FLUCAFD_BC_DIRICHLET:
       bcs[0].value = 0.;
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
     default:
       break;
     }
-    PetscCall(FlucaFDSetBoundaryConditions(fd_tvd, bcs));
+    PetscCall(FlucaFDSetBoundaryConditions(fd_tvd, 0, bcs));
   }
 
   PetscCall(FlucaFDSecondOrderTVDSetVelocity(fd_tvd, vel, 0));
@@ -140,21 +140,21 @@ int main(int argc, char **argv)
   test:
     suffix: left_bc_dirichlet
     nsize: 1
-    args: -i 0 -flucafd_left_bc_type dirichlet
+    args: -i 0 -flucafd_0_left_bc_type dirichlet
 
   test:
     suffix: left_bc_neumann
     nsize: 1
-    args: -i 0 -flucafd_left_bc_type neumann
+    args: -i 0 -flucafd_0_left_bc_type neumann
 
   test:
     suffix: right_bc_dirichlet
     nsize: 1
-    args: -i 8 -flucafd_right_bc_type dirichlet
+    args: -i 8 -flucafd_0_right_bc_type dirichlet
 
   test:
     suffix: right_bc_neumann
     nsize: 1
-    args: -i 8 -flucafd_right_bc_type neumann
+    args: -i 8 -flucafd_0_right_bc_type neumann
 
 TEST*/

--- a/fluca/tests/fd/ex7.c
+++ b/fluca/tests/fd/ex7.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 
   /* Set boundary conditions */
   {
-    FlucaFDBoundaryCondition bcs[2];
+    FlucaFDBoundaryCondition bcs[2] = {{0}};
 
     bcs[0].type  = FLUCAFD_BC_DIRICHLET;
     bcs[0].value = 0.;

--- a/fluca/tests/fd/ex9.c
+++ b/fluca/tests/fd/ex9.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
   PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
   bcs_const[0].value = left_val;
   bcs_const[1].value = right_val;
-  PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_const, 0, bcs_const));
   PetscCall(FlucaFDSetFromOptions(fd_const));
   PetscCall(FlucaFDSetUp(fd_const));
 
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   bcs_fn[1].value  = 99.;
   bcs_fn[1].fn     = ConstValBCFn;
   bcs_fn[1].fn_ctx = &right_val;
-  PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_fn, 0, bcs_fn));
   PetscCall(FlucaFDSetFromOptions(fd_fn));
   PetscCall(FlucaFDSetUp(fd_fn));
 
@@ -111,13 +111,13 @@ int main(int argc, char **argv)
   test:
     suffix: dirichlet_fn
     nsize: 1
-    args: -flucafd_left_bc_type dirichlet -flucafd_right_bc_type dirichlet -left_val 0 -right_val 1
+    args: -flucafd_0_left_bc_type dirichlet -flucafd_0_right_bc_type dirichlet -left_val 0 -right_val 1
     output_file: output/empty.out
 
   test:
     suffix: neumann_fn
     nsize: 1
-    args: -flucafd_left_bc_type neumann -flucafd_right_bc_type neumann -left_val 0 -right_val 2
+    args: -flucafd_0_left_bc_type neumann -flucafd_0_right_bc_type neumann -left_val 0 -right_val 2
     output_file: output/empty.out
 
 TEST*/

--- a/fluca/tests/fd/ex9.c
+++ b/fluca/tests/fd/ex9.c
@@ -1,0 +1,184 @@
+#include <flucafd.h>
+#include <flucasys.h>
+#include <petscdmstag.h>
+#include <petscmath.h>
+
+static const char help[] = "Test FlucaFD function-based boundary condition values\n"
+                           "Options:\n"
+                           "  -M <int>  : Number of elements (default 8)\n";
+
+/* Constant-equivalent BC function: returns 2.0 always */
+static PetscErrorCode ConstantBCFn(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value)
+{
+  PetscFunctionBeginUser;
+  *value = 2.0;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/* Position-dependent Dirichlet BC function: value = x[0]^2 */
+static PetscErrorCode PositionBCFn(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value)
+{
+  PetscFunctionBeginUser;
+  *value = x[0] * x[0];
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/* Fill input vector with u(x) = x^2 */
+static PetscErrorCode FillInputVector(DM dm, Vec u)
+{
+  Vec                 u_local;
+  PetscInt            x, m, i, slot_elem;
+  PetscScalar       **arr;
+  const PetscScalar **arr_coord;
+  PetscInt            slot_coord_elem;
+
+  PetscFunctionBeginUser;
+  PetscCall(DMStagGetProductCoordinateArraysRead(dm, &arr_coord, NULL, NULL));
+  PetscCall(DMStagGetProductCoordinateLocationSlot(dm, DMSTAG_ELEMENT, &slot_coord_elem));
+  PetscCall(DMStagGetLocationSlot(dm, DMSTAG_ELEMENT, 0, &slot_elem));
+  PetscCall(DMStagGetCorners(dm, &x, NULL, NULL, &m, NULL, NULL, NULL, NULL, NULL));
+
+  PetscCall(DMGetLocalVector(dm, &u_local));
+  PetscCall(VecZeroEntries(u_local));
+  PetscCall(DMStagVecGetArray(dm, u_local, &arr));
+  for (i = x; i < x + m; ++i) {
+    PetscReal xi      = PetscRealPart(arr_coord[i][slot_coord_elem]);
+    arr[i][slot_elem] = xi * xi;
+  }
+  PetscCall(DMStagVecRestoreArray(dm, u_local, &arr));
+  PetscCall(DMLocalToGlobal(dm, u_local, INSERT_VALUES, u));
+  PetscCall(DMRestoreLocalVector(dm, &u_local));
+  PetscCall(DMStagRestoreProductCoordinateArraysRead(dm, &arr_coord, NULL, NULL));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **argv)
+{
+  DM       dm;
+  PetscInt M;
+
+  PetscCall(FlucaInitialize(&argc, &argv, NULL, help));
+
+  M = 8;
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-M", &M, NULL));
+
+  PetscCall(DMStagCreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, M, 0, 1, DMSTAG_STENCIL_BOX, 1, NULL, &dm));
+  PetscCall(DMSetUp(dm));
+  PetscCall(DMStagSetUniformCoordinatesProduct(dm, 0., 1., 0., 0., 0., 0.));
+
+  /* Test 1: constant-equivalent function BC applied via FlucaFDApply
+     Compare result of constant BC value=2.0 vs function BC that returns 2.0.
+     Both should give the same derivative values for du/dx with left Dirichlet BC.
+     u(x) = x^2, du/dx = 2x, left BC = 0.0 (or 0.0^2=0.0 from function) */
+  {
+    FlucaFDBoundaryCondition bcs_const[2] = {{0}}, bcs_fn[2] = {{0}};
+    FlucaFD                  fd_const, fd_fn;
+    Vec                      u, y_const, y_fn;
+    PetscScalar              norm_diff;
+
+    /* Create constant-BC derivative operator */
+    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
+    bcs_const[0].type  = FLUCAFD_BC_DIRICHLET;
+    bcs_const[0].value = 0.; /* u(0) = 0 */
+    bcs_const[1].type  = FLUCAFD_BC_DIRICHLET;
+    bcs_const[1].value = 1.; /* u(1) = 1 */
+    PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
+    PetscCall(FlucaFDSetUp(fd_const));
+
+    /* Create function-BC derivative operator */
+    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_fn));
+    bcs_fn[0].type  = FLUCAFD_BC_DIRICHLET;
+    bcs_fn[0].value = 0.;           /* fallback constant, overridden by fn */
+    bcs_fn[0].fn    = PositionBCFn; /* PositionBCFn(x=0)=0, matches constant */
+    bcs_fn[1].type  = FLUCAFD_BC_DIRICHLET;
+    bcs_fn[1].value = 1.;           /* fallback constant, overridden by fn */
+    bcs_fn[1].fn    = PositionBCFn; /* PositionBCFn(x=1)=1, matches constant */
+    PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
+    PetscCall(FlucaFDSetUp(fd_fn));
+
+    /* Fill input vector u(x) = x^2 */
+    PetscCall(DMCreateGlobalVector(dm, &u));
+    PetscCall(FillInputVector(dm, u));
+
+    /* Apply both and compare */
+    PetscCall(DMCreateGlobalVector(dm, &y_const));
+    PetscCall(DMCreateGlobalVector(dm, &y_fn));
+    PetscCall(FlucaFDApply(fd_const, dm, dm, u, y_const));
+    PetscCall(FlucaFDApply(fd_fn, dm, dm, u, y_fn));
+
+    PetscCall(VecAXPY(y_fn, -1.0, y_const));
+    PetscCall(VecNorm(y_fn, NORM_INFINITY, &norm_diff));
+    PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = %g\n", (double)PetscRealPart(norm_diff)));
+
+    PetscCall(VecDestroy(&y_fn));
+    PetscCall(VecDestroy(&y_const));
+    PetscCall(VecDestroy(&u));
+    PetscCall(FlucaFDDestroy(&fd_fn));
+    PetscCall(FlucaFDDestroy(&fd_const));
+  }
+
+  /* Test 2: Neumann function BC - apply derivative with Neumann BC function
+     u(x) = x^2, du/dx|_{x=0} = 0, du/dx|_{x=1} = 2
+     For second-order derivative with Neumann left BC = 0, right BC = 2 */
+  {
+    FlucaFD                  fd_const, fd_fn;
+    FlucaFDBoundaryCondition bcs_const[2] = {{0}}, bcs_fn[2] = {{0}};
+    Vec                      u, y_const, y_fn;
+    PetscScalar              norm_diff;
+
+    /* Constant Neumann BC operator */
+    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 2, 2, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
+    bcs_const[0].type  = FLUCAFD_BC_NEUMANN;
+    bcs_const[0].value = 0.; /* du/dx = 0 at x=0 */
+    bcs_const[1].type  = FLUCAFD_BC_NEUMANN;
+    bcs_const[1].value = 2.; /* du/dx = 2 at x=1 */
+    PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
+    PetscCall(FlucaFDSetUp(fd_const));
+
+    /* Function Neumann BC operator: constant fn returning 0 and 2 */
+    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 2, 2, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_fn));
+    bcs_fn[0].type  = FLUCAFD_BC_NEUMANN;
+    bcs_fn[0].value = 99.;          /* should be overridden by fn */
+    bcs_fn[0].fn    = ConstantBCFn; /* returns 2.0 - different from bcs_const[0].value=0 intentionally */
+    bcs_fn[1].type  = FLUCAFD_BC_NEUMANN;
+    bcs_fn[1].value = 99.; /* should be overridden by fn */
+    PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
+    PetscCall(FlucaFDSetUp(fd_fn));
+
+    PetscCall(DMCreateGlobalVector(dm, &u));
+    PetscCall(FillInputVector(dm, u));
+
+    PetscCall(DMCreateGlobalVector(dm, &y_const));
+    PetscCall(DMCreateGlobalVector(dm, &y_fn));
+    PetscCall(FlucaFDApply(fd_const, dm, dm, u, y_const));
+    PetscCall(FlucaFDApply(fd_fn, dm, dm, u, y_fn));
+
+    /* The results should differ because ConstantBCFn returns 2.0 not 0.0 for left BC */
+    PetscCall(VecAXPY(y_fn, -1.0, y_const));
+    PetscCall(VecNorm(y_fn, NORM_INFINITY, &norm_diff));
+    PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = %g\n", (double)PetscRealPart(norm_diff)));
+
+    PetscCall(VecDestroy(&y_fn));
+    PetscCall(VecDestroy(&y_const));
+    PetscCall(VecDestroy(&u));
+    PetscCall(FlucaFDDestroy(&fd_fn));
+    PetscCall(FlucaFDDestroy(&fd_const));
+  }
+
+  PetscCall(DMDestroy(&dm));
+  PetscCall(FlucaFinalize());
+}
+
+/*TEST
+
+  test:
+    suffix: bc_fn_const_equiv
+    nsize: 1
+    args: -M 8
+
+  test:
+    suffix: bc_fn_neumann_differs
+    nsize: 1
+    args: -M 8
+
+TEST*/

--- a/fluca/tests/fd/ex9.c
+++ b/fluca/tests/fd/ex9.c
@@ -1,25 +1,17 @@
 #include <flucafd.h>
 #include <flucasys.h>
 #include <petscdmstag.h>
-#include <petscmath.h>
 
 static const char help[] = "Test FlucaFD function-based boundary condition values\n"
                            "Options:\n"
-                           "  -M <int>  : Number of elements (default 8)\n";
+                           "  -left_val <real>  : BC value on the left boundary\n"
+                           "  -right_val <real> : BC value on the right boundary\n";
 
-/* Constant-equivalent BC function: returns 2.0 always */
-static PetscErrorCode ConstantBCFn(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value)
+/* BC function: returns constant value from ctx */
+static PetscErrorCode ConstValBCFn(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value)
 {
   PetscFunctionBeginUser;
-  *value = 2.0;
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/* Position-dependent Dirichlet BC function: value = x[0]^2 */
-static PetscErrorCode PositionBCFn(PetscInt dim, const PetscReal x[], void *ctx, PetscScalar *value)
-{
-  PetscFunctionBeginUser;
-  *value = x[0] * x[0];
+  *value = *(PetscScalar *)ctx;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -54,117 +46,62 @@ static PetscErrorCode FillInputVector(DM dm, Vec u)
 
 int main(int argc, char **argv)
 {
-  DM       dm;
-  PetscInt M;
+  DM                       dm;
+  FlucaFD                  fd_const, fd_fn;
+  FlucaFDBoundaryCondition bcs_const[2] = {{0}}, bcs_fn[2] = {{0}};
+  Vec                      u, y_const, y_fn;
+  PetscReal                norm_diff;
+  PetscScalar              left_val = 0., right_val = 0.;
 
   PetscCall(FlucaInitialize(&argc, &argv, NULL, help));
 
-  M = 8;
-  PetscCall(PetscOptionsGetInt(NULL, NULL, "-M", &M, NULL));
+  PetscCall(PetscOptionsGetScalar(NULL, NULL, "-left_val", &left_val, NULL));
+  PetscCall(PetscOptionsGetScalar(NULL, NULL, "-right_val", &right_val, NULL));
 
-  PetscCall(DMStagCreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, M, 0, 1, DMSTAG_STENCIL_BOX, 1, NULL, &dm));
+  PetscCall(DMStagCreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, 8, 0, 1, DMSTAG_STENCIL_BOX, 1, NULL, &dm));
+  PetscCall(DMSetFromOptions(dm));
   PetscCall(DMSetUp(dm));
   PetscCall(DMStagSetUniformCoordinatesProduct(dm, 0., 1., 0., 0., 0., 0.));
 
-  /* Test 1: constant-equivalent function BC applied via FlucaFDApply
-     Compare result of constant BC value=2.0 vs function BC that returns 2.0.
-     Both should give the same derivative values for du/dx with left Dirichlet BC.
-     u(x) = x^2, du/dx = 2x, left BC = 0.0 (or 0.0^2=0.0 from function) */
-  {
-    FlucaFDBoundaryCondition bcs_const[2] = {{0}}, bcs_fn[2] = {{0}};
-    FlucaFD                  fd_const, fd_fn;
-    Vec                      u, y_const, y_fn;
-    PetscScalar              norm_diff;
+  /* Reference operator with constant BC values */
+  PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
+  bcs_const[0].value = left_val;
+  bcs_const[1].value = right_val;
+  PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
+  PetscCall(FlucaFDSetFromOptions(fd_const));
+  PetscCall(FlucaFDSetUp(fd_const));
 
-    /* Create constant-BC derivative operator */
-    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
-    bcs_const[0].type  = FLUCAFD_BC_DIRICHLET;
-    bcs_const[0].value = 0.; /* u(0) = 0 */
-    bcs_const[1].type  = FLUCAFD_BC_DIRICHLET;
-    bcs_const[1].value = 1.; /* u(1) = 1 */
-    PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
-    PetscCall(FlucaFDSetUp(fd_const));
+  /* Function-based operator: ConstValBCFn returns the same values from ctx.
+     Set value=99 to verify fn takes priority over value. */
+  PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_fn));
+  bcs_fn[0].value  = 99.;
+  bcs_fn[0].fn     = ConstValBCFn;
+  bcs_fn[0].fn_ctx = &left_val;
+  bcs_fn[1].value  = 99.;
+  bcs_fn[1].fn     = ConstValBCFn;
+  bcs_fn[1].fn_ctx = &right_val;
+  PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
+  PetscCall(FlucaFDSetFromOptions(fd_fn));
+  PetscCall(FlucaFDSetUp(fd_fn));
 
-    /* Create function-BC derivative operator */
-    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 1, 1, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_fn));
-    bcs_fn[0].type  = FLUCAFD_BC_DIRICHLET;
-    bcs_fn[0].value = 0.;           /* fallback constant, overridden by fn */
-    bcs_fn[0].fn    = PositionBCFn; /* PositionBCFn(x=0)=0, matches constant */
-    bcs_fn[1].type  = FLUCAFD_BC_DIRICHLET;
-    bcs_fn[1].value = 1.;           /* fallback constant, overridden by fn */
-    bcs_fn[1].fn    = PositionBCFn; /* PositionBCFn(x=1)=1, matches constant */
-    PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
-    PetscCall(FlucaFDSetUp(fd_fn));
+  /* Apply both and assert results match */
+  PetscCall(DMCreateGlobalVector(dm, &u));
+  PetscCall(FillInputVector(dm, u));
 
-    /* Fill input vector u(x) = x^2 */
-    PetscCall(DMCreateGlobalVector(dm, &u));
-    PetscCall(FillInputVector(dm, u));
+  PetscCall(DMCreateGlobalVector(dm, &y_const));
+  PetscCall(DMCreateGlobalVector(dm, &y_fn));
+  PetscCall(FlucaFDApply(fd_const, dm, dm, u, y_const));
+  PetscCall(FlucaFDApply(fd_fn, dm, dm, u, y_fn));
 
-    /* Apply both and compare */
-    PetscCall(DMCreateGlobalVector(dm, &y_const));
-    PetscCall(DMCreateGlobalVector(dm, &y_fn));
-    PetscCall(FlucaFDApply(fd_const, dm, dm, u, y_const));
-    PetscCall(FlucaFDApply(fd_fn, dm, dm, u, y_fn));
+  PetscCall(VecAXPY(y_fn, -1.0, y_const));
+  PetscCall(VecNorm(y_fn, NORM_INFINITY, &norm_diff));
+  PetscCheck(norm_diff < PETSC_SMALL, PETSC_COMM_WORLD, PETSC_ERR_PLIB, "||y_fn - y_const||_inf = %g exceeds tolerance", (double)norm_diff);
 
-    PetscCall(VecAXPY(y_fn, -1.0, y_const));
-    PetscCall(VecNorm(y_fn, NORM_INFINITY, &norm_diff));
-    PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = %g\n", (double)PetscRealPart(norm_diff)));
-
-    PetscCall(VecDestroy(&y_fn));
-    PetscCall(VecDestroy(&y_const));
-    PetscCall(VecDestroy(&u));
-    PetscCall(FlucaFDDestroy(&fd_fn));
-    PetscCall(FlucaFDDestroy(&fd_const));
-  }
-
-  /* Test 2: Neumann function BC - apply derivative with Neumann BC function
-     u(x) = x^2, du/dx|_{x=0} = 0, du/dx|_{x=1} = 2
-     For second-order derivative with Neumann left BC = 0, right BC = 2 */
-  {
-    FlucaFD                  fd_const, fd_fn;
-    FlucaFDBoundaryCondition bcs_const[2] = {{0}}, bcs_fn[2] = {{0}};
-    Vec                      u, y_const, y_fn;
-    PetscScalar              norm_diff;
-
-    /* Constant Neumann BC operator */
-    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 2, 2, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_const));
-    bcs_const[0].type  = FLUCAFD_BC_NEUMANN;
-    bcs_const[0].value = 0.; /* du/dx = 0 at x=0 */
-    bcs_const[1].type  = FLUCAFD_BC_NEUMANN;
-    bcs_const[1].value = 2.; /* du/dx = 2 at x=1 */
-    PetscCall(FlucaFDSetBoundaryConditions(fd_const, bcs_const));
-    PetscCall(FlucaFDSetUp(fd_const));
-
-    /* Function Neumann BC operator: constant fn returning 0 and 2 */
-    PetscCall(FlucaFDDerivativeCreate(dm, FLUCAFD_X, 2, 2, DMSTAG_ELEMENT, 0, DMSTAG_ELEMENT, 0, &fd_fn));
-    bcs_fn[0].type  = FLUCAFD_BC_NEUMANN;
-    bcs_fn[0].value = 99.;          /* should be overridden by fn */
-    bcs_fn[0].fn    = ConstantBCFn; /* returns 2.0 - different from bcs_const[0].value=0 intentionally */
-    bcs_fn[1].type  = FLUCAFD_BC_NEUMANN;
-    bcs_fn[1].value = 99.; /* should be overridden by fn */
-    PetscCall(FlucaFDSetBoundaryConditions(fd_fn, bcs_fn));
-    PetscCall(FlucaFDSetUp(fd_fn));
-
-    PetscCall(DMCreateGlobalVector(dm, &u));
-    PetscCall(FillInputVector(dm, u));
-
-    PetscCall(DMCreateGlobalVector(dm, &y_const));
-    PetscCall(DMCreateGlobalVector(dm, &y_fn));
-    PetscCall(FlucaFDApply(fd_const, dm, dm, u, y_const));
-    PetscCall(FlucaFDApply(fd_fn, dm, dm, u, y_fn));
-
-    /* The results should differ because ConstantBCFn returns 2.0 not 0.0 for left BC */
-    PetscCall(VecAXPY(y_fn, -1.0, y_const));
-    PetscCall(VecNorm(y_fn, NORM_INFINITY, &norm_diff));
-    PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = %g\n", (double)PetscRealPart(norm_diff)));
-
-    PetscCall(VecDestroy(&y_fn));
-    PetscCall(VecDestroy(&y_const));
-    PetscCall(VecDestroy(&u));
-    PetscCall(FlucaFDDestroy(&fd_fn));
-    PetscCall(FlucaFDDestroy(&fd_const));
-  }
-
+  PetscCall(VecDestroy(&y_fn));
+  PetscCall(VecDestroy(&y_const));
+  PetscCall(VecDestroy(&u));
+  PetscCall(FlucaFDDestroy(&fd_fn));
+  PetscCall(FlucaFDDestroy(&fd_const));
   PetscCall(DMDestroy(&dm));
   PetscCall(FlucaFinalize());
 }
@@ -172,13 +109,15 @@ int main(int argc, char **argv)
 /*TEST
 
   test:
-    suffix: bc_fn_const_equiv
+    suffix: dirichlet_fn
     nsize: 1
-    args: -M 8
+    args: -flucafd_left_bc_type dirichlet -flucafd_right_bc_type dirichlet -left_val 0 -right_val 1
+    output_file: output/empty.out
 
   test:
-    suffix: bc_fn_neumann_differs
+    suffix: neumann_fn
     nsize: 1
-    args: -M 8
+    args: -flucafd_left_bc_type neumann -flucafd_right_bc_type neumann -left_val 0 -right_val 2
+    output_file: output/empty.out
 
 TEST*/

--- a/fluca/tests/fd/output/ex10_per_component_bcs.out
+++ b/fluca/tests/fd/output/ex10_per_component_bcs.out
@@ -1,0 +1,16 @@
+Stencil at i=0 (left boundary):
+  npoints = 6
+  points[0]: type=grid, i=0, loc=ELEMENT, c=0, v=8.
+  points[1]: type=grid, i=1, loc=ELEMENT, c=0, v=2.66667
+  points[2]: type=grid, i=0, loc=ELEMENT, c=1, v=-4.
+  points[3]: type=grid, i=1, loc=ELEMENT, c=1, v=4.
+  points[4]: type=boundary(left), i=0, loc=LEFT, c=0, v=-10.6667
+  points[5]: type=boundary(left), i=0, loc=LEFT, c=1, v=0.5
+Stencil at i=7 (right boundary):
+  npoints = 6
+  points[0]: type=grid, i=6, loc=ELEMENT, c=0, v=-2.66667
+  points[1]: type=grid, i=7, loc=ELEMENT, c=0, v=-8.
+  points[2]: type=grid, i=6, loc=ELEMENT, c=1, v=-4.
+  points[3]: type=grid, i=7, loc=ELEMENT, c=1, v=4.
+  points[4]: type=boundary(right), i=8, loc=LEFT, c=0, v=10.6667
+  points[5]: type=boundary(right), i=8, loc=LEFT, c=1, v=0.5

--- a/fluca/tests/fd/output/ex9_bc_fn_const_equiv.out
+++ b/fluca/tests/fd/output/ex9_bc_fn_const_equiv.out
@@ -1,2 +1,0 @@
-Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = 0.
-Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = 809.739

--- a/fluca/tests/fd/output/ex9_bc_fn_const_equiv.out
+++ b/fluca/tests/fd/output/ex9_bc_fn_const_equiv.out
@@ -1,0 +1,2 @@
+Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = 0.
+Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = 809.739

--- a/fluca/tests/fd/output/ex9_bc_fn_neumann_differs.out
+++ b/fluca/tests/fd/output/ex9_bc_fn_neumann_differs.out
@@ -1,2 +1,0 @@
-Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = 0.
-Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = 809.739

--- a/fluca/tests/fd/output/ex9_bc_fn_neumann_differs.out
+++ b/fluca/tests/fd/output/ex9_bc_fn_neumann_differs.out
@@ -1,0 +1,2 @@
+Test 1 (const-equiv function BC): ||y_fn - y_const||_inf = 0.
+Test 2 (Neumann function BC differs from const): ||y_fn - y_const||_inf = 809.739

--- a/fluca/tutorials/fd/ex1.c
+++ b/fluca/tutorials/fd/ex1.c
@@ -49,7 +49,7 @@ static PetscErrorCode CreateConvectionDiffusionOperator(AppCtx *ctx, FlucaFD *fd
   FlucaFD                  fd_scaled_tvd, fd_conv_deriv, fd_conv;
   FlucaFD                  fd_diff_inner, fd_diff_scaled, fd_diff_outer, fd_diff, fd_neg_diff;
   FlucaFD                  operands[2];
-  FlucaFDBoundaryCondition bcs[2];
+  FlucaFDBoundaryCondition bcs[2] = {{0}};
 
   PetscFunctionBegin;
 

--- a/fluca/tutorials/fd/ex1.c
+++ b/fluca/tutorials/fd/ex1.c
@@ -60,7 +60,7 @@ static PetscErrorCode CreateConvectionDiffusionOperator(AppCtx *ctx, FlucaFD *fd
 
   /* Convection operator: d/dx(rho * u * phi) */
   PetscCall(FlucaFDSecondOrderTVDCreate(ctx->dm, FLUCAFD_X, 0, 0, &ctx->fd_tvd));
-  PetscCall(FlucaFDSetBoundaryConditions(ctx->fd_tvd, bcs));
+  PetscCall(FlucaFDSetBoundaryConditions(ctx->fd_tvd, 0, bcs));
   PetscCall(FlucaFDSetFromOptions(ctx->fd_tvd));
   PetscCall(FlucaFDSetUp(ctx->fd_tvd));
 
@@ -71,7 +71,7 @@ static PetscErrorCode CreateConvectionDiffusionOperator(AppCtx *ctx, FlucaFD *fd
   PetscCall(FlucaFDSetUp(fd_conv_deriv));
 
   PetscCall(FlucaFDCompositionCreate(fd_scaled_tvd, fd_conv_deriv, &fd_conv));
-  PetscCall(FlucaFDSetBoundaryConditions(fd_conv, bcs));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_conv, 0, bcs));
   PetscCall(FlucaFDSetUp(fd_conv));
 
   /* Negative diffusion operator: - d/dx(gamma * d/dx phi) */
@@ -88,14 +88,14 @@ static PetscErrorCode CreateConvectionDiffusionOperator(AppCtx *ctx, FlucaFD *fd
   PetscCall(FlucaFDSetUp(fd_diff));
 
   PetscCall(FlucaFDScaleCreateConstant(fd_diff, -1., &fd_neg_diff));
-  PetscCall(FlucaFDSetBoundaryConditions(fd_neg_diff, bcs));
+  PetscCall(FlucaFDSetBoundaryConditions(fd_neg_diff, 0, bcs));
   PetscCall(FlucaFDSetUp(fd_neg_diff));
 
   /* Sum */
   operands[0] = fd_conv;
   operands[1] = fd_neg_diff;
   PetscCall(FlucaFDSumCreate(2, operands, fd_convdiff));
-  PetscCall(FlucaFDSetBoundaryConditions(*fd_convdiff, bcs));
+  PetscCall(FlucaFDSetBoundaryConditions(*fd_convdiff, 0, bcs));
   PetscCall(FlucaFDSetUp(*fd_convdiff));
 
   /* Cleanup intermediate operators */

--- a/fluca/tutorials/fd/ex1.c
+++ b/fluca/tutorials/fd/ex1.c
@@ -115,7 +115,7 @@ static PetscErrorCode ComputeFunction(SNES snes, Vec x, Vec b, void *ptr)
   AppCtx *ctx = (AppCtx *)ptr;
 
   PetscFunctionBegin;
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, x));
   PetscCall(FlucaFDApply(ctx->fd, ctx->dm, ctx->dm, x, b));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -126,7 +126,7 @@ static PetscErrorCode ComputeJacobian(SNES snes, Vec x, Mat A, Mat P, void *ptr)
   AppCtx *ctx = (AppCtx *)ptr;
 
   PetscFunctionBegin;
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, x));
   PetscCall(MatZeroEntries(A));
   PetscCall(FlucaFDGetOperator(ctx->fd, ctx->dm, ctx->dm, A));

--- a/fluca/tutorials/fd/ex2.c
+++ b/fluca/tutorials/fd/ex2.c
@@ -71,7 +71,7 @@ static PetscErrorCode ComputeRHSFunction(TS ts, PetscReal t, Vec u, Vec F, void 
 
   PetscFunctionBegin;
   /* Update TVD operator with current solution and velocity */
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, u));
 
   PetscCall(FlucaFDApply(ctx->fd, ctx->dm, ctx->dm, u, F));
@@ -85,7 +85,7 @@ static PetscErrorCode ComputeRHSJacobian(TS ts, PetscReal t, Vec u, Mat A, Mat P
   AppCtx *ctx = (AppCtx *)ptr;
 
   PetscFunctionBegin;
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, u));
 
   PetscCall(MatZeroEntries(A));

--- a/fluca/tutorials/fd/ex3.c
+++ b/fluca/tutorials/fd/ex3.c
@@ -145,9 +145,9 @@ static PetscErrorCode ComputeRHSFunction(TS ts, PetscReal t, Vec u, Vec F, void 
 
   PetscFunctionBegin;
   /* Update TVD operators with current solution and velocity */
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd_x, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd_x, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd_x, u));
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd_y, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd_y, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd_y, u));
 
   /* RHS = operator(u) (operator already has correct signs) */
@@ -160,9 +160,9 @@ static PetscErrorCode ComputeRHSJacobian(TS ts, PetscReal t, Vec u, Mat A, Mat P
   AppCtx *ctx = (AppCtx *)ptr;
 
   PetscFunctionBegin;
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd_x, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd_x, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd_x, u));
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd_y, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd_y, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd_y, u));
 
   PetscCall(MatZeroEntries(A));

--- a/fluca/tutorials/fd/ex4.c
+++ b/fluca/tutorials/fd/ex4.c
@@ -108,7 +108,7 @@ static PetscErrorCode ComputeRHSFunction(TS ts, PetscReal t, Vec x, Vec F, void 
 
   /* Update operators with current velocity and solution */
   PetscCall(FlucaFDScaleSetVector(ctx->fd_scale_vel, ctx->vel, DMSTAG_LEFT, 0));
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, x));
 
   PetscCall(FlucaFDApply(ctx->fd, ctx->dm, ctx->dm, x, F));
@@ -127,7 +127,7 @@ static PetscErrorCode ComputeRHSJacobian(TS ts, PetscReal t, Vec x, Mat A, Mat P
 
   /* Update operators with current velocity and solution */
   PetscCall(FlucaFDScaleSetVector(ctx->fd_scale_vel, ctx->vel, DMSTAG_LEFT, 0));
-  PetscCall(FlucaFDSecondOrderTVDSetVelocity(ctx->fd_tvd, ctx->vel, 0));
+  PetscCall(FlucaFDSecondOrderTVDSetMassFlux(ctx->fd_tvd, ctx->vel, 0));
   PetscCall(FlucaFDSecondOrderTVDSetCurrentSolution(ctx->fd_tvd, x));
 
   PetscCall(MatZeroEntries(A));


### PR DESCRIPTION
## Summary

- Support function-based boundary condition values via `FlucaFDBCValueFn` callback, enabling spatially varying BCs
- Support per-component boundary conditions (each DOF component can have independent BC type/value)
- Rename velocity to mass flux in TVD convection API (`FlucaFDSecondOrderTVDSetVelocity` → `FlucaFDSecondOrderTVDSetMassFlux`)
- Add `ex9` (function-based BC test) and `ex10` (per-component BC test) with golden outputs

## Test plan

- [x] All 56 unit tests pass (`ctest -R tests_`)
- [x] Build succeeds with no warnings