### PR TITLE
Enforce continuity as a DAE in Phys INS and document the coupled IMEX solver

### DIFF
--- a/THEORY_GUIDE.md
+++ b/THEORY_GUIDE.md
@@ -140,7 +140,7 @@ The spatial operators are:
 
 - $\mathbf{N}(\mathbf{u})$: convection, discretized with a second-order TVD scheme built on the face mass flux $\rho\overline{\mathbf{u}}$;
 - $\mathbf{L}$: viscous Laplacian, $(\mathbf{L}\mathbf{u})_i = \delta^2 u_i / \delta x_j \delta x_j$;
-- $\mathbf{B}^\top$: cell-centered pressure gradient, $(\mathbf{B}^\top p)_i = \delta p / \delta x_i$. The symbol follows the saddle-point convention of Elman et al. [4] and Quarteroni et al. [7], in which $\mathbf{B}$ is the discrete divergence and $\mathbf{B}^\top$ the discrete gradient. The transpose is genuine here up to sign: the assembled blocks satisfy $\mathbf{D} = -\mathbf{B}$ exactly on every interior row, which is the discrete integration-by-parts identity $\langle \mathbf{B}^\top p, \mathbf{u}\rangle = -\langle p, \mathbf{B}\mathbf{u}\rangle$. It is not exact on boundary rows, where the velocity Dirichlet conditions imposed on $\mathbf{D}$ and the pressure Neumann conditions imposed on $\mathbf{B}^\top$ are not adjoint to one another; under periodic boundaries, which have no such rows, the identity holds everywhere;
+- $\mathbf{B}^\top$: cell-centered pressure gradient, $(\mathbf{B}^\top p)_i = \delta p / \delta x_i$. The symbol follows the saddle-point convention of Elman et al. [4] and Quarteroni et al. [6], in which $\mathbf{B}$ is the discrete divergence and $\mathbf{B}^\top$ the discrete gradient. The transpose is genuine here up to sign: the assembled blocks satisfy $\mathbf{D} = -\mathbf{B}$ exactly on every interior row, which is the discrete integration-by-parts identity $\langle \mathbf{B}^\top p, \mathbf{u}\rangle = -\langle p, \mathbf{B}\mathbf{u}\rangle$. It is not exact on boundary rows, where the velocity Dirichlet conditions imposed on $\mathbf{D}$ and the pressure Neumann conditions imposed on $\mathbf{B}^\top$ are not adjoint to one another; under periodic boundaries, which have no such rows, the identity holds everywhere;
 - $\mathbf{T}$: interpolation of a cell-centered vector to the face normal, $\mathbf{T}\mathbf{v} = \overline{\mathbf{v}} \cdot \mathbf{n}$, where $\overline{(\cdot)}$ denotes linear interpolation from the two adjacent cell centers;
 - $\mathbf{B}^\top_\text{st}$: staggered face-normal pressure gradient, evaluated compactly at the face, $\mathbf{B}^\top_\text{st}\, p = \left. \delta p / \delta n \right|_\text{face}$;
 - $\mathbf{D}_\text{st}$: staggered divergence, acting on a face-normal field, $\mathbf{D}_\text{st} U = \sum_i \delta U_i / \delta x_i$;
@@ -220,7 +220,7 @@ is singular: the pressure is an algebraic variable that instantaneously enforces
 
 ### IMEX Runge-Kutta Advancement
 
-`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{G}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{G}$ the non-stiff terms (advanced explicitly) [6]. The terms of (9) and (12) are sorted by stiffness:
+`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{G}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{G}$ the non-stiff terms (advanced explicitly) [5]. The terms of (9) and (12) are sorted by stiffness:
 
 ```math
 \mathbf{F} = \begin{bmatrix} \rho \dot{\mathbf{u}} - \mu \mathbf{L}\mathbf{u} + \mathbf{B}^\top p \\ \mathbf{D}\mathbf{u} + \mathbf{C} p \end{bmatrix}, \qquad
@@ -249,11 +249,11 @@ The stage matrix (14) is the saddle-point system (13) with the velocity block $\
 \qquad \mathbf{S} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{B}^\top \tag{15}
 ```
 
-Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\mathbf{S}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another.
+Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\mathbf{S}$) — the classical pressure-velocity decoupling sweep, now used to precondition rather than to time-advance. Elman et al. [4] showed that SIMPLE is exactly such an approximate block factorization.
 
 #### Two independent approximations
 
-Following the nomenclature of Quarteroni et al. [7] as adopted by Elman et al. [4], group the lower and diagonal factors of (15) together, (LD)U:
+Following the nomenclature of Quarteroni et al. [6] as adopted by Elman et al. [4], group the lower and diagonal factors of (15) together, (LD)U:
 
 ```math
 \mathbf{J} =
@@ -285,16 +285,15 @@ Reading off the two blocks of $\mathbf{E}$:
 1. The **momentum** equation is unperturbed iff $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ (_momentum preserving_) — only the pressure gradient seen by the velocity is affected, never the velocity operator itself.
 2. The **continuity** equation is unperturbed iff $\widetilde{\mathbf{A}}_1 = \widetilde{\mathbf{A}}_2$ (_mass preserving_) — the two approximations need not be accurate, only **consistent with each other**.
 
-Approximating the Schur complement alone is therefore _not_ what defines the fractional step method or SIMPLE. Both are mass-preserving schemes: they use the **same** cheap inverse in the Schur complement and in the velocity correction, and accept a perturbed momentum equation in exchange for an exactly satisfied discrete continuity equation. Keeping $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ while approximating only $\widetilde{\mathbf{A}}_1$ gives a different — momentum-preserving — member of the same family, in which continuity is the perturbed equation.
+Approximating the Schur complement alone is therefore _not_ what defines SIMPLE. It is a mass-preserving scheme: it uses the **same** cheap inverse in the Schur complement and in the velocity correction, and accepts a perturbed momentum equation in exchange for an exactly satisfied discrete continuity equation. Keeping $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ while approximating only $\widetilde{\mathbf{A}}_1$ gives a different — momentum-preserving — member of the same family, in which continuity is the perturbed equation.
 
 | Scheme | $\widetilde{\mathbf{A}}_1$ | $\widetilde{\mathbf{A}}_2$ | Unperturbed |
 | --- | --- | --- | --- |
 | Exact block factorization | $\mathbf{A}$ | $\mathbf{A}$ | both |
-| Fractional step [5] | $\text{shift}\,\rho\,\mathbf{I}$ | $\text{shift}\,\rho\,\mathbf{I}$ | continuity |
 | SIMPLE [4] | $\operatorname{diag}(\mathbf{A})$ | $\operatorname{diag}(\mathbf{A})$ | continuity |
 | Schur-only approximation | $\ne \mathbf{A}$ | $\mathbf{A}$ | momentum |
 
-The fractional-step and SIMPLE choices coincide as $\Delta t \to 0$, where $\operatorname{diag}(\mathbf{A})$ is dominated by the mass term $\text{shift}\,\rho$. Because the split preconditions an outer Krylov iteration, the fully coupled solution is recovered independently of the choice; only the iteration count differs.
+Because the split preconditions an outer Krylov iteration, the fully coupled solution is recovered independently of the choice; only the iteration count differs.
 
 #### Mapping onto `PCFIELDSPLIT`
 
@@ -348,6 +347,5 @@ Because nothing is baked into the operators, the Jacobian is untouched: $\mathbf
 2. Y. Zang, R. L. Street, and J. R. Koseff, A non-staggered grid, fractional step method for time-dependent incompressible Navier–Stokes equations in curvilinear coordinates, _J. Comput. Phys._, 114, 18&ndash;33 (1994).
 3. S. Armfield and R. Street, The pressure accuracy of fractional-step methods for the Navier-Stokes equations on staggered grids, _ANZIAM J._, 44, C20&ndash;C39 (2003).
 4. H. Elman, V. E. Howle, J. Shadid, R. Shuttleworth, and R. Tuminaro, A taxonomy and comparison of parallel block multi-level preconditioners for the incompressible Navier–Stokes equations, _J. Comput. Phys._, 227, 1790&ndash;1808 (2008)
-5. J. Perot, An analysis of the fractional step method, _J. Comput. Phys._, 108, 51&ndash;58 (1993).
-6. U. M. Ascher, S. J. Ruuth, and R. J. Spiteri, Implicit-explicit Runge-Kutta methods for time-dependent partial differential equations, _Appl. Numer. Math._, 25, 151&ndash;167 (1997).
-7. A. Quarteroni, F. Saleri, and A. Veneziani, Factorization methods for the numerical approximation of Navier&ndash;Stokes equations, _Comput. Methods Appl. Mech. Engrg._, 188, 505&ndash;526 (2000).
+5. U. M. Ascher, S. J. Ruuth, and R. J. Spiteri, Implicit-explicit Runge-Kutta methods for time-dependent partial differential equations, _Appl. Numer. Math._, 25, 151&ndash;167 (1997).
+6. A. Quarteroni, F. Saleri, and A. Veneziani, Factorization methods for the numerical approximation of Navier&ndash;Stokes equations, _Comput. Methods Appl. Mech. Engrg._, 188, 505&ndash;526 (2000).

--- a/THEORY_GUIDE.md
+++ b/THEORY_GUIDE.md
@@ -9,7 +9,7 @@ This document presents the theoretical foundations and numerical methods impleme
 - [Temporal Discretization](#temporal-discretization)
 - [Spatial Discretization](#spatial-discretization)
 - [Immersed Boundary Method](#immersed-boundary-method)
-- [Segregated Solvers](#segregated-solvers)
+- [Matrix Form of the Discrete System](#matrix-form-of-the-discrete-system)
 - [Coupled IMEX Formulation](#coupled-imex-formulation)
 
 ## Governing Equations
@@ -132,256 +132,85 @@ For a two-dimensional Cartesian grid, the discrete divergence of velocity at cel
 
 <!-- TODO: -->
 
-## Segregated Solvers
+## Matrix Form of the Discrete System
 
-### Matrix Form of the Discretized Governing Equations
+The discretized governing equations are expressed in matrix form using discrete operators. This representation exposes the saddle-point structure of the coupled system and is the basis for the preconditioner analysis that follows. All operators are defined **unscaled** — no $\Delta t$ or $\rho$ factor is folded into them — and this single operator set is used throughout the remainder of the guide.
 
-To facilitate the development and analysis of solution algorithms, the discretized governing equations are expressed in matrix form using discrete operators. This representation elucidates the structure of the coupled system and enables rigorous analysis of solution methods.
+The spatial operators are:
 
-The following discrete operators are defined. The operator $\mathbf{A}$ represents the implicit part of the momentum equation, comprising the identity (from the time derivative), the convective terms, and the viscous terms:
+- $\mathbf{N}(\mathbf{u})$: convection, discretized with a second-order TVD scheme built on the face mass flux $\rho\overline{\mathbf{u}}$;
+- $\mathbf{L}$: viscous Laplacian, $(\mathbf{L}\mathbf{u})_i = \delta^2 u_i / \delta x_j \delta x_j$;
+- $\mathbf{G}$: cell-centered pressure gradient, $(\mathbf{G}p)_i = \delta p / \delta x_i$;
+- $\mathbf{T}$: interpolation of a cell-centered vector to the face normal, $\mathbf{T}\mathbf{v} = \overline{\mathbf{v}} \cdot \mathbf{n}$, where $\overline{(\cdot)}$ denotes linear interpolation from the two adjacent cell centers;
+- $\mathbf{G}^\text{st}$: staggered face-normal pressure gradient, evaluated compactly at the face, $\mathbf{G}^\text{st}p = \left. \delta p / \delta n \right|_\text{face}$;
+- $\mathbf{D}_0$: divergence of a face-normal field, $\mathbf{D}_0 U = \sum_i \delta U_i / \delta x_i$;
+- $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$: divergence of the interpolated velocity, carrying the factor $\rho$.
 
-```math
-(\mathbf{A}\mathbf{u}^{n+1})_i = u_i^{n+1} + \frac{\Delta t}{2} \frac{\delta}{\delta x_j} (\overline{u}_i^{n+1} U^n + \overline{u}_i^n \overline{u}_j^{n+1})  - \frac{\Delta t}{2} \frac{\delta}{\delta x_j} \left( \nu^{n+1} \frac{\delta u_i^{n+1}}{\delta x_j} \right)
-```
+### Momentum Equation
 
-The operator $\mathbf{G}$ represents the (scaled) cell-centered pressure gradient:
-
-```math
-(\mathbf{G}p)_i = \frac{\Delta t}{\rho} \frac{\delta p}{\delta x_i}
-```
-
-The operator $\mathbf{D}$ represents the discrete divergence operator applied to the face-normal velocities:
+Discretizing the momentum equation (2) in space while leaving time continuous gives, for the cell-centered velocity $\mathbf{u}$ and pressure $p$:
 
 ```math
-\mathbf{D}U^{n+1} = \sum_i \frac{\delta U^{n+1}}{\delta x_i}
+\rho \frac{d\mathbf{u}}{dt} + \mathbf{N}(\mathbf{u}) + \mathbf{G} p = \mu \mathbf{L} \mathbf{u} + \mathbf{f}(t) \tag{9}
 ```
 
-Using these operators, the discretized momentum equation (6) takes the compact form:
+where $\mathbf{f}$ collects body forces and the boundary-condition contributions of the viscous and pressure operators.
+
+### Rhie-Chow Interpolation and Pressure Stabilization
+
+The face-normal velocity is not an independent unknown: it is the derived quantity supplied by the Rhie-Chow interpolation (7). Interpolating the cell-centered velocity to the faces directly would leave each cell pressure decoupled from its own gradient and admit checkerboard modes; the interpolation therefore carries a pressure-gradient correction. In operator form,
 
 ```math
-\mathbf{A}\mathbf{u}^{n+1} + \mathbf{G}p' = u_i^n + \frac{\Delta t}{2} \frac{\delta}{\delta x_j} \left( \nu^n \frac{\delta u_i^n}{\delta x_j} \right) - \frac{\Delta t}{\rho} \frac{\delta q}{\delta x_i} \equiv \mathbf{r} \tag{9}
+U = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\left( \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \right) p = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\,\mathbf{R}\, p, \qquad \mathbf{R} = \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \tag{10}
 ```
 
-where $\mathbf{r}$ represents the right-hand side consisting of known quantities from the previous time step. The discretized continuity equation (8) becomes:
+where $\mathbf{R}$ is the Rhie-Chow correction operator: the difference between the interpolated cell pressure gradient and the compact gradient evaluated directly at the face. Because the compact face gradient couples the two adjacent cell pressures, this correction removes the odd-even decoupling. Following Zang et al. [2], the coefficient is fixed at $\Delta t / \rho$ rather than taken from the momentum-equation diagonal as in the classical Rhie-Chow scheme.
+
+The discrete continuity equation is the vanishing divergence of these face-normal velocities, $\mathbf{D}_0 U = 0$, which on substituting (10) becomes
 
 ```math
-\mathbf{D}U^{n+1} = 0 \tag{10}
+\mathbf{D}_0 \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\, \mathbf{D}_0 \mathbf{R}\, p = 0
 ```
 
-To complete the operator notation, the Rhie-Chow interpolation is expressed using two additional operators. Let $\mathbf{T}$ denote the operator that linearly interpolates a cell-centered vector to the faces and extracts its normal component:
+The two products in $\mathbf{D}_0\mathbf{R} = \mathbf{D}_0\mathbf{T}\mathbf{G} - \mathbf{D}_0\mathbf{G}^\text{st}$ are two discrete Laplacians of the pressure: $\mathbf{D}_0\mathbf{T}\mathbf{G}$ interpolates the cell gradient before differencing, a **wide** ($2\Delta x$-stencil) Laplacian, whereas $\mathbf{D}_0\mathbf{G}^\text{st}$ differences the compact face gradient, a **compact** (nearest-neighbor) Laplacian. Their difference defines the pressure-stabilization operator:
 
 ```math
-\mathbf{T}\mathbf{v} = \overline{\mathbf{v}} \cdot \mathbf{n}
+\mathbf{S} = \mathbf{D}_0\mathbf{R} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact} \tag{11}
 ```
 
-Let $\mathbf{G}^\text{st}$ denote the operator that computes the scaled face-normal pressure gradient directly at the face (the staggered gradient):
+Multiplying through by $\rho$ and identifying $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$ and the stabilization coefficient $\sigma_0 = \Delta t$ gives the stabilized continuity constraint in cell-centered form:
 
 ```math
-\mathbf{G}^\text{st}p = \frac{\Delta t}{\rho} \left. \frac{\delta p}{\delta n} \right|_\text{face}
+\mathbf{D} \mathbf{u} + \sigma_0 \mathbf{S} p = 0 \tag{12}
 ```
 
-The Rhie-Chow interpolation (7) then takes the form:
+Since $\mathbf{D}$ already carries $\rho$, the effective coefficient relative to $\nabla \cdot \mathbf{u}$ is $\Delta t / \rho$, the classical Rhie-Chow coefficient [2]. The stabilization $\sigma_0 \mathbf{S}$ is therefore nothing but the divergence of the Rhie-Chow correction, written as a cell-centered pressure operator. It vanishes to the order of the truncation error for smooth pressure fields — where the wide and compact Laplacians agree — and acts only on the under-resolved checkerboard modes, which is precisely the coupling the collocated grid requires. Because $U$ has been eliminated, the discrete system carries only the two cell-centered fields $(\mathbf{u}, p)$.
+
+### Saddle-Point Structure
+
+Any implicit time discretization of (9) turns the velocity terms into a single velocity block $\mathbf{A}$ acting on the new-time velocity, leaving the pressure gradient, the constraint (12), and known right-hand-side data. The result is the two-field saddle-point system
 
 ```math
-U^{n+1} = \mathbf{T}\mathbf{u}^{n+1} + \mathbf{T}\mathbf{G}p' - \mathbf{G}^\text{st}p' = \mathbf{T}\mathbf{u}^{n+1} + \mathbf{R}p' \tag{11}
+\begin{bmatrix} \mathbf{A} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix}
+\begin{bmatrix} \mathbf{u} \\ p \end{bmatrix} =
+\begin{bmatrix} \mathbf{r} + \mathbf{b}_\text{mom} \\ b_\text{cont} \end{bmatrix} \tag{13}
 ```
 
-where $\mathbf{R} = \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st}$ represents the Rhie-Chow correction operator. Combining equations (9), (10), and (11) yields a fully coupled matrix system for the unknowns $\mathbf{u}^{n+1}$, $U^{n+1}$, and $p'$:
+where $\mathbf{r}$ holds the known terms from previous time levels and $\mathbf{b}_\text{mom}$, $b_\text{cont}$ the constant contributions of the boundary conditions. Only $\mathbf{A}$ depends on the time discretization; the off-diagonal blocks and the stabilized $(2,2)$ block are the same for every scheme. The Crank-Nicolson advancement of the Temporal Discretization chapter gives one such $\mathbf{A}$ — its equations are the momentum balance (9) multiplied through by $\Delta t / \rho$, which is why $\Delta t / \rho$ appears there on the pressure gradient and not here — and the IMEX Runge-Kutta stage operator of the next chapter gives another.
 
-```math
-\begin{bmatrix} \mathbf{A} & 0 & \mathbf{G} \\ -\mathbf{T} & \mathbf{I} & -\mathbf{R} \\ 0 & \mathbf{D} & 0 \end{bmatrix} \begin{bmatrix} \mathbf{u}^{n+1} \\ U^{n+1} \\ p' \end{bmatrix} = \begin{bmatrix} \mathbf{r} \\ 0 \\ 0 \end{bmatrix} \tag{12}
-```
+For non-constant viscosity — an eddy viscosity depending on the velocity field, for instance — $\mathbf{A}$ depends on the unknowns and the system must be solved iteratively; with constant viscosity and an explicitly treated convection term it is linear.
 
-In practice, boundary conditions introduce additional constant terms in the right-hand side vector:
-
-```math
-\begin{bmatrix} \mathbf{A} & 0 & \mathbf{G} \\ -\mathbf{T} & \mathbf{I} & -\mathbf{R} \\ 0 & \mathbf{D} & 0 \end{bmatrix} \begin{bmatrix} \mathbf{u}^{n+1} \\ U^{n+1} \\ p' \end{bmatrix} = \begin{bmatrix} \mathbf{r} + \mathbf{b}_\text{mom} \\ b_\text{interp} \\ b_\text{cont} \end{bmatrix} \tag{13}
-```
-
-For non-constant viscosity, such as eddy viscosity dependent on the velocity field from a turbulence model, the matrix depends on the unknowns, necessitating iterative solution. Some formulations treat the Rhie-Chow correction term via _deferred correction_:
-
-```math
-\begin{bmatrix} \mathbf{A} & 0 & \mathbf{G} \\ -\mathbf{T} & \mathbf{I} & 0 \\ 0 & \mathbf{D} & 0 \end{bmatrix} \begin{bmatrix} \mathbf{u}^{n+1} \\ U^{n+1} \\ p' \end{bmatrix} = \begin{bmatrix} \mathbf{r} + \mathbf{b}_\text{mom} \\ \mathbf{R}p' + b_\text{interp} \\ b_\text{cont} \end{bmatrix}
-```
-
-This form requires iteration even for constant viscosity, but yields a simpler matrix structure.
-
-The resulting systems are large, sparse, and possess saddle-point structure. Direct solution is computationally expensive. Fluca employs solution strategies based on approximate block factorization preconditioners.
-
-### Approximate Block Factorization Preconditioners
-
-Elman et al. [4] demonstrated that several classical solvers, including SIMPLE, can be formulated as stationary iterations:
-
-```math
-\mathbf{x}^{k+1} = \mathbf{x}^k + (\widetilde{\mathbf{M}}^k)^{-1} (\mathbf{f}^k - \mathbf{M}^k \mathbf{x}^k) \tag{14}
-```
-
-where $\widetilde{\mathbf{M}}$ is an approximation to the matrix $\mathbf{M}$. This is equivalent to one step of preconditioned Richardson iteration, with $\widetilde{\mathbf{M}}^{-1}$ serving as the preconditioner. For rapid convergence, $\widetilde{\mathbf{M}}$ must satisfy two conditions:
-
-1. The approximation error $\mathbf{M} - \widetilde{\mathbf{M}}$ should be small.
-2. The system $\widetilde{\mathbf{M}} \mathbf{y} = \mathbf{r}$ should be efficiently solvable.
-
-Block factorizations of the original matrix provide natural candidates for such approximations.
-
-Fluca employs the following decomposition to construct the approximation:
-
-```math
-\mathbf{M} =
-\begin{bmatrix}
-\mathbf{I} & 0 & 0 \\ 0 & \mathbf{I} & 0 \\ \mathbf{D}\mathbf{T}\mathbf{A}^{-1} & \mathbf{D} & \mathbf{I}
-\end{bmatrix}
-\begin{bmatrix}
-\mathbf{A} & 0 & 0 \\ -\mathbf{T} & \mathbf{I} & 0 \\ 0 & 0 & \mathbf{S}
-\end{bmatrix}
-\begin{bmatrix}
-\mathbf{I} & 0 & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} & \mathbf{T}\mathbf{A}^{-1}\mathbf{G} - \mathbf{R} \\ 0 & 0 & \mathbf{I}
-\end{bmatrix} \tag{15}
-```
-
-This decomposition is derived from the LDU decomposition of $\mathbf{M}$ viewed as a $2 \times 2$ block matrix:
-
-```math
-\mathbf{M} =
-\begin{bmatrix}
-\mathbf{M}_{11} & \mathbf{M}_{12} \\ \mathbf{M}_{21} & \mathbf{M}_{22}
-\end{bmatrix}
-```
-
-```math
-\mathbf{M}_{11} =
-\begin{bmatrix}
-\mathbf{A} & 0 \\ -\mathbf{T} & \mathbf{I}
-\end{bmatrix}
-, \quad
-\mathbf{M}_{12} =
-\begin{bmatrix}
-\mathbf{G} \\ -\mathbf{R}
-\end{bmatrix}
-, \quad
-\mathbf{M}_{21} =
-\begin{bmatrix}
-0 & \mathbf{D}
-\end{bmatrix}
-, \quad
-\mathbf{M}_{22} =
-\begin{bmatrix}
-0
-\end{bmatrix}
-```
-
-where $\mathbf{S} = -\mathbf{D}\mathbf{T}\mathbf{A}^{-1}\mathbf{G}+\mathbf{D}\mathbf{R}$ denotes the Schur complement.
-
-Fluca groups the lower triangular matrix and the diagonal matrix to form the following (LD)U decomposition:
-
-```math
-\mathbf{M} =
-\begin{bmatrix}
-\mathbf{A} & 0 & 0 \\ -\mathbf{T} & \mathbf{I} & 0 \\ 0 & \mathbf{D} & \mathbf{S}
-\end{bmatrix}
-\begin{bmatrix}
-\mathbf{I} & 0 & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} & \mathbf{T}\mathbf{A}^{-1}\mathbf{G} - \mathbf{R} \\ 0 & 0 & \mathbf{I}
-\end{bmatrix}
-```
-
-Let $\widetilde{\mathbf{A}}_1$ denote the approximation to $\mathbf{A}$ appearing in the Schur complement, and $\widetilde{\mathbf{A}}_2$ denote the approximation to $\mathbf{A}$ appearing in the upper triangular matrix. The approximate matrix $\widetilde{\mathbf{M}}$ is then:
-
-```math
-\widetilde{\mathbf{M}} =
-\begin{bmatrix}
-\mathbf{A} & 0 & 0 \\ -\mathbf{T} & \mathbf{I} & 0 \\ 0 & \mathbf{D} & \widetilde{\mathbf{S}}
-\end{bmatrix}
-\begin{bmatrix}
-\mathbf{I} & 0 & \widetilde{\mathbf{A}}_2^{-1}\mathbf{G} \\ 0 & \mathbf{I} & \mathbf{T}\widetilde{\mathbf{A}}_2^{-1}\mathbf{G} - \mathbf{R} \\ 0 & 0 & \mathbf{I}
-\end{bmatrix} \tag{16}
-```
-
-with the approximate Schur complement $\widetilde{\mathbf{S}}=-\mathbf{D}\mathbf{T}\widetilde{\mathbf{A}}_1^{-1}\mathbf{G}+\mathbf{D}\mathbf{R}$.
-
-The error of this approximation is:
-
-```math
-\mathbf{E} = \mathbf{M} - \widetilde{\mathbf{M}} =
-\begin{bmatrix}
-0 & 0 & (\mathbf{I}-\mathbf{A}\widetilde{\mathbf{A}}_2^{-1})\mathbf{G} \\
-0 & 0 & 0 \\
-0 & 0 & \mathbf{D}\mathbf{T}(\widetilde{\mathbf{A}}_1^{-1}-\widetilde{\mathbf{A}}_2^{-1})\mathbf{G}
-\end{bmatrix} \tag{17}
-```
-
-From this expression, it can be concluded that:
-
-1. The momentum equation is unperturbed if $\widetilde{\mathbf{A}}_2 = \mathbf{A}$.
-2. The Rhie-Chow interpolation is always unperturbed.
-3. The continuity equation is unperturbed if $\widetilde{\mathbf{A}}_1 = \widetilde{\mathbf{A}}_2$.
-
-The following sections describe how specific solvers construct the matrix decomposition and select $\widetilde{\mathbf{A}}_1$ and $\widetilde{\mathbf{A}}_2$ to satisfy these conditions.
-
-### Fractional Step Method
-
-Perot [5] demonstrated that the fractional step method (FSM) can be interpreted as an approximate block LU decomposition of the coupled matrix system. This perspective establishes the FSM as a member of the approximate block factorization preconditioner family.
-
-Zang et al. [2] presented the FSM for collocated grids. Applied to the matrix system (13), the solution procedure consists of the following steps:
-
-1. Solve $\mathbf{A}\mathbf{u}^* = \mathbf{r} + \mathbf{b}_\text{mom}$ for the intermediate velocity $\mathbf{u}^*$.
-2. Compute the face-normal intermediate velocity: $U^* = \mathbf{T}\mathbf{u}^* + b_\text{interp}$.
-3. Solve the pressure Poisson equation $\mathbf{D}\mathbf{G}^\text{st}p' = \mathbf{D}U^* + b_\text{cont}$ for $p'$.
-4. Correct the velocity: $\mathbf{u}^{n+1} = \mathbf{u}^* - \mathbf{G}p'$.
-5. Correct the face-normal velocity: $U^{n+1} = U^* - \mathbf{G}^\text{st}p'$.
-
-The corresponding matrix decomposition is:
-
-```math
-\widetilde{\mathbf{M}} =
-\begin{bmatrix}
-\mathbf{A} & 0 & 0 \\ \mathbf{T} & -\mathbf{I} & 0 \\ 0 & \mathbf{D} & -\mathbf{D}\mathbf{G}^\text{st}
-\end{bmatrix}
-\begin{bmatrix} \mathbf{I} & 0 & \mathbf{G} \\ 0 & \mathbf{I} & \mathbf{G}^\text{st} \\ 0 & 0 & \mathbf{I}
-\end{bmatrix} \tag{18}
-```
-
-This decomposition is easily invertible due to its simple approximate Schur complement $\widetilde{\mathbf{S}} = -\mathbf{D}\mathbf{G}^\text{st}$, which corresponds to a discrete Laplacian operator.
-
-Comparing (18) with (16), the approximations to $\mathbf{A}$ are identified as:
-
-```math
-\widetilde{\mathbf{A}}_1 = \widetilde{\mathbf{A}}_2 = \mathbf{I} \tag{19}
-```
-
-The continuity equation remains unperturbed.
+The matrix in (13) is large, sparse, and indefinite: the $(2,2)$ block is not the zero block of a classical saddle-point problem, but neither is it definite enough to make the system easy. Direct factorization is prohibitive beyond small grids, so Fluca solves it with a Krylov method preconditioned by an approximate block factorization, developed in the next chapter.
 
 ## Coupled IMEX Formulation
 
-Fluca's `Phys` module solves the incompressible equations as a fully coupled system in time. The semi-discretized equations are cast as a differential-algebraic system and advanced with an implicit-explicit (IMEX) Runge-Kutta integrator driving PETSc's `TS` directly. Unlike the segregated solvers above, the velocity-pressure coupling is retained and solved to convergence at every step; the classical pressure-velocity decoupling reappears here only as a family of _preconditioners_ for the coupled system, never as the time advancement itself.
+Fluca's `Phys` module solves the incompressible equations as a fully coupled system in time. The semi-discrete system (9), (12) is cast as a differential-algebraic system and advanced with an implicit-explicit (IMEX) Runge-Kutta integrator driving PETSc's `TS` directly. The velocity-pressure coupling is retained and solved to convergence at every step; the classical pressure-velocity decoupling reappears here only as a family of _preconditioners_ for the coupled system, never as the time advancement itself.
 
-Three differences from the segregated notation should be noted, since several symbols are reused with new meanings.
+The discrete operators of the previous chapter are used unchanged, and the stage matrix is the saddle-point system (13). The only new symbols are the Schur complement $\widehat{\mathbf{S}}$ and its approximation $\widetilde{\mathbf{S}}$, both distinct from the pressure-stabilization operator $\mathbf{S}$ of (11).
 
-1. This formulation carries no separate face-normal unknown $U$: the Rhie-Chow interpolation is eliminated analytically and reappears as a cell-centered pressure-stabilization term, leaving a two-field system in $(\mathbf{u}, p)$.
-2. The pressure-gradient operators $\mathbf{G}$, $\mathbf{G}^\text{st}$ and the Rhie-Chow correction $\mathbf{R}$ are _unscaled_ here; the $\Delta t / \rho$ factor folded into them in the segregated chapter is written out explicitly below. The divergence $\mathbf{D}$ also changes meaning: it acts on the cell-centered velocity and carries a factor $\rho$, whereas the segregated $\mathbf{D}$ acts on the face-normal velocity $U$ and carries no $\rho$. Consequently $\sigma_0 = \Delta t$ alone, the $\rho$ having been absorbed into $\mathbf{D}$.
-3. $\mathbf{S}$ denotes the **pressure-stabilization** operator here, not the Schur complement it denotes in the segregated chapter. The Schur complement of this chapter is written $\widehat{\mathbf{S}}$, and its approximation $\widetilde{\mathbf{S}}$.
+### Differential-Algebraic Structure
 
-### Pressure-Stabilized Semi-Discrete System
-
-Discretizing the momentum and continuity equations in space while leaving time continuous, and folding the Rhie-Chow correction into a cell-centered pressure-stabilization operator, yields for the cell-centered velocity $\mathbf{u}$ and pressure $p$:
-
-```math
-\rho \frac{d\mathbf{u}}{dt} + \mathbf{N}(\mathbf{u}) + \mathbf{G} p = \mu \mathbf{L} \mathbf{u} + \mathbf{f}(t) \tag{20}
-```
-
-```math
-\mathbf{D} \mathbf{u} + \sigma_0 \mathbf{S} p = 0 \tag{21}
-```
-
-where the discrete operators are
-
-- $\mathbf{N}$: convection, discretized with a second-order TVD scheme built on the face mass flux $\rho \overline{\mathbf{u}}$;
-- $\mathbf{G}$: cell-centered pressure gradient (unscaled);
-- $\mathbf{L}$: viscous Laplacian;
-- $\mathbf{D} = \rho \, \delta \overline{\mathbf{u}} / \delta x_i$: divergence of the interpolated velocity (carrying the factor $\rho$);
-- $\mathbf{S} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact}$: pressure stabilization, the difference between the wide (interpolated-gradient) and compact discrete Laplacians. It is the cell-centered form of the collocated Rhie-Chow correction [2], coupling pressure and velocity to suppress the checkerboard modes.
-
-The stabilization coefficient is $\sigma_0 = \Delta t$; since $\mathbf{D}$ already carries $\rho$, the effective coefficient relative to $\nabla \cdot \mathbf{u}$ is $\Delta t / \rho$, the classical Rhie-Chow coefficient [2].
-
-Because the continuity equation (21) contains no time derivative, the system is a **differential-algebraic equation** (DAE). Written as $\mathbf{M}\, d\mathbf{y}/dt = \dots$ with $\mathbf{y} = (\mathbf{u}, p)$, the mass matrix
+Because the stabilized continuity constraint (12) contains no time derivative, the pair (9), (12) is a **differential-algebraic equation** (DAE). Written as $\mathbf{M}\, d\mathbf{y}/dt = \dots$ with $\mathbf{y} = (\mathbf{u}, p)$, the mass matrix
 
 ```math
 \mathbf{M} = \begin{bmatrix} \rho \mathbf{I} & 0 \\ 0 & 0 \end{bmatrix}
@@ -389,39 +218,9 @@ Because the continuity equation (21) contains no time derivative, the system is 
 
 is singular: the pressure is an algebraic variable that instantaneously enforces stabilized incompressibility. The stabilization $\sigma_0 \mathbf{S}$ is what makes this constraint solvable on the collocated grid, by suppressing the checkerboard pressure modes.
 
-### Rhie-Chow Interpolation and Pressure Stabilization
-
-The stabilization operator $\mathbf{S}$ in Eq. (21) originates from the Rhie-Chow interpolation of the face-normal velocity, Eq. (7). Interpolating the cell-centered velocity to the faces directly would leave each cell pressure decoupled from its own gradient and admit checkerboard modes; instead the face-normal velocity carries a pressure-gradient correction:
-
-```math
-U = \overline{\mathbf{u}} \cdot \mathbf{n} + \frac{\Delta t}{\rho}\left( \overline{\nabla p} \cdot \mathbf{n} - \left. \frac{\partial p}{\partial n} \right|_\text{face} \right)
-```
-
-Here $\overline{(\cdot)}$ denotes linear interpolation from the two adjacent cell centers to the face. The first term is ordinary interpolation; the correction is the difference between the interpolated cell pressure gradient and the compact gradient evaluated directly at the face. Because the compact face gradient couples the two adjacent cell pressures, this correction removes the odd-even decoupling. Following Zang et al. [2], the coefficient is fixed at $\Delta t / \rho$ rather than taken from the momentum-equation diagonal as in the classical Rhie-Chow scheme.
-
-Reusing the interpolation operator $\mathbf{T}$ (cell velocity to face normal), and writing $\mathbf{G}$ and $\mathbf{G}^\text{st}$ for the _unscaled_ cell-centered and staggered face-normal pressure gradients — that is, $\mathbf{G}p = \delta p / \delta x_i$ and $\mathbf{G}^\text{st}p = \delta p / \delta n |_\text{face}$, without the $\Delta t / \rho$ carried by their segregated-chapter counterparts — the face velocity becomes
-
-```math
-U = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\left( \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \right) p = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\,\mathbf{R}\, p, \qquad \mathbf{R} = \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st}
-```
-
-which is Eq. (11) with the $\Delta t / \rho$ scaling written out. The discrete continuity equation is the divergence of these face-normal velocities; writing $\mathbf{D}_0$ for that divergence operator ($\mathbf{D}_0 U = \sum_i \delta U_i / \delta x_i$),
-
-```math
-\mathbf{D}_0 \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\, \mathbf{D}_0 \mathbf{R}\, p = 0
-```
-
-The two products in $\mathbf{D}_0\mathbf{R} = \mathbf{D}_0\mathbf{T}\mathbf{G} - \mathbf{D}_0\mathbf{G}^\text{st}$ are two discrete Laplacians of the pressure: $\mathbf{D}_0\mathbf{T}\mathbf{G}$ interpolates the cell gradient before differencing, a **wide** ($2\Delta x$-stencil) Laplacian, whereas $\mathbf{D}_0\mathbf{G}^\text{st}$ differences the compact face gradient, a **compact** (nearest-neighbor) Laplacian. Their difference is the stabilization operator:
-
-```math
-\mathbf{S} = \mathbf{D}_0\mathbf{R} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact}
-```
-
-Multiplying the continuity relation by $\rho$ and identifying the divergence of the interpolated velocity $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$ and $\sigma_0 = \Delta t$ recovers the stabilized constraint (21), $\mathbf{D}\mathbf{u} + \sigma_0 \mathbf{S} p = 0$. The stabilization $\sigma_0 \mathbf{S}$ is therefore the divergence of the Rhie-Chow correction. It vanishes to the order of the truncation error for smooth pressure fields — where the wide and compact Laplacians agree — and acts only on the under-resolved checkerboard modes, which is precisely the coupling required by the collocated grid.
-
 ### IMEX Runge-Kutta Advancement
 
-`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{g}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{g}$ the non-stiff terms (advanced explicitly) [6]. PETSc's documentation calls the explicit part $\mathbf{G}$; it is renamed $\mathbf{g}$ here to avoid a collision with the pressure-gradient operator. The terms of (20)-(21) are sorted by stiffness:
+`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{g}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{g}$ the non-stiff terms (advanced explicitly) [6]. PETSc's documentation calls the explicit part $\mathbf{G}$; it is renamed $\mathbf{g}$ here to avoid a collision with the pressure-gradient operator. The terms of (9) and (12) are sorted by stiffness:
 
 ```math
 \mathbf{F} = \begin{bmatrix} \rho \dot{\mathbf{u}} - \mu \mathbf{L}\mathbf{u} + \mathbf{G} p \\ \mathbf{D}\mathbf{u} + \sigma_0 \mathbf{S} p \end{bmatrix}, \qquad
@@ -433,33 +232,33 @@ The viscous term (parabolic-stiff), pressure gradient, and the algebraic continu
 For an $s$-stage scheme with a diagonally-implicit tableau $a^I$, stage $i$ requires an implicit solve whose Jacobian is $\mathbf{J} = \text{shift}\cdot\mathbf{M} + \partial\mathbf{F}/\partial\mathbf{y}$, with the stage shift $\text{shift} = 1/(a^I_{ii}\,\Delta t)$:
 
 ```math
-\mathbf{J} = \begin{bmatrix} \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix} \tag{22}
+\mathbf{J} = \begin{bmatrix} \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix} \tag{14}
 ```
 
 The singular pressure block of $\mathbf{M}$ contributes nothing to $\mathbf{J}$; the corresponding diagonal is instead supplied by the stabilization $\sigma_0 \mathbf{S}$, so $\mathbf{J}$ is nonsingular apart from the constant-pressure null space (removed by a null-space projection). A **stiffly-accurate** scheme (e.g. `ARKIMEX3`) is required so that the algebraic pressure is advanced at the full order of the method.
 
 ### Schur-Complement Preconditioning
 
-The stage matrix (22) is a saddle-point system for the collocated two-field unknowns $(\mathbf{u}, p)$, in which the face-normal velocity has been eliminated and the Rhie-Chow correction absorbed into $\sigma_0 \mathbf{S}$. Writing $\mathbf{A} = \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L}$ and $\mathbf{C} = \sigma_0 \mathbf{S}$, it admits the block LDU factorization
+The stage matrix (14) is the saddle-point system (13) with the velocity block $\mathbf{A} = \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L}$ supplied by the IMEX stage. Abbreviating the stabilized $(2,2)$ block as $\mathbf{C} = \sigma_0 \mathbf{S}$, it admits the block LDU factorization
 
 ```math
 \mathbf{J} =
 \begin{bmatrix} \mathbf{I} & 0 \\ \mathbf{D}\mathbf{A}^{-1} & \mathbf{I} \end{bmatrix}
 \begin{bmatrix} \mathbf{A} & 0 \\ 0 & \widehat{\mathbf{S}} \end{bmatrix}
 \begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix},
-\qquad \widehat{\mathbf{S}} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G} \tag{23}
+\qquad \widehat{\mathbf{S}} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G} \tag{15}
 ```
 
-Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\widehat{\mathbf{S}}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another. This is the two-field counterpart of the three-block decomposition (15) of the segregated solvers.
+Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\widehat{\mathbf{S}}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another.
 
 #### Two independent approximations
 
-Following the nomenclature of Quarteroni et al. [7] as adopted by Elman et al. [4], group the lower and diagonal factors of (23) together, (LD)U:
+Following the nomenclature of Quarteroni et al. [7] as adopted by Elman et al. [4], group the lower and diagonal factors of (15) together, (LD)U:
 
 ```math
 \mathbf{J} =
 \begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \widehat{\mathbf{S}} \end{bmatrix}
-\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix} \tag{24}
+\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix} \tag{16}
 ```
 
 The $\mathbf{A}^{-1}$ of the lower factor cancels against the diagonal block, so exactly **two** occurrences of $\mathbf{A}^{-1}$ survive, and they are approximated independently:
@@ -467,7 +266,7 @@ The $\mathbf{A}^{-1}$ of the lower factor cancels against the diagonal block, so
 - $\widetilde{\mathbf{A}}_1$ — the approximation in the **Schur complement**, $\widetilde{\mathbf{S}} = \mathbf{C} - \mathbf{D}\widetilde{\mathbf{A}}_1^{-1}\mathbf{G}$, i.e. in the pressure-Poisson operator;
 - $\widetilde{\mathbf{A}}_2$ — the approximation in the **upper triangular factor**, i.e. in the velocity correction $\mathbf{u}^{n+1} = \mathbf{u}^* - \widetilde{\mathbf{A}}_2^{-1}\mathbf{G}p'$.
 
-These are the same two approximations identified in (16) for the segregated system. The resulting preconditioner — written $\widetilde{\mathbf{J}}$, since here it approximates the stage Jacobian $\mathbf{J}$ rather than the $\widetilde{\mathbf{M}}$ of the segregated chapter — and its error are
+The resulting preconditioner $\widetilde{\mathbf{J}}$ and its error are
 
 ```math
 \widetilde{\mathbf{J}} =
@@ -478,7 +277,7 @@ These are the same two approximations identified in (16) for the segregated syst
 \begin{bmatrix}
 0 & (\mathbf{I} - \mathbf{A}\widetilde{\mathbf{A}}_2^{-1})\mathbf{G} \\
 0 & \mathbf{D}(\widetilde{\mathbf{A}}_1^{-1} - \widetilde{\mathbf{A}}_2^{-1})\mathbf{G}
-\end{bmatrix} \tag{25}
+\end{bmatrix} \tag{17}
 ```
 
 Reading off the two blocks of $\mathbf{E}$:
@@ -508,11 +307,11 @@ The fractional-step and SIMPLE choices coincide as $\Delta t \to 0$, where $\ope
 | Preconditioner matrix for the Schur block | `-pc_fieldsplit_schur_precondition` | PETSc default: $\mathbf{A}_{11} = \sigma_0\mathbf{S}$ |
 | $\widetilde{\mathbf{A}}_2$ in the velocity correction | `-fieldsplit_pressure_upper_` | PETSc default: reuses the velocity solve |
 
-Only one prefix appears for the lower and diagonal factors because `PCFIELDSPLIT`, although it documents the `full` factorization as the plain LDU product, applies it in the fused (LD)U grouping of (24): a single solve with $\mathbf{A}$ produces both the predicted velocity and the argument of $\mathbf{D}\mathbf{u}^*$ that forms the Schur right-hand side. Each preconditioner application therefore costs **two** solves with $\mathbf{A}$ — the predictor and the velocity correction — rather than the three a literal L·D·U application would require.
+Only one prefix appears for the lower and diagonal factors because `PCFIELDSPLIT`, although it documents the `full` factorization as the plain LDU product, applies it in the fused (LD)U grouping of (16): a single solve with $\mathbf{A}$ produces both the predicted velocity and the argument of $\mathbf{D}\mathbf{u}^*$ that forms the Schur right-hand side. Each preconditioner application therefore costs **two** solves with $\mathbf{A}$ — the predictor and the velocity correction — rather than the three a literal L·D·U application would require.
 
 Note that the second solve does not disappear when $\widetilde{\mathbf{A}}_2$ is a cheap approximation. When a separate upper solver is configured (`kspUpper != kspA` in `PCApply_FieldSplit_Schur`), PETSc recomputes the predictor with $\mathbf{A}$ before applying $\widetilde{\mathbf{A}}_2^{-1}$, so the exact $\mathbf{A}$-solve count stays at two and only the *correction* becomes cheap. The saving from a cheap $\widetilde{\mathbf{A}}_2$ is in the correction, not in the predictor count.
 
-The cancellation that produces the fused grouping is algebraic only for a fixed linear operator; if the velocity `KSP` is an inexact Krylov method, the two solves with $\mathbf{A}$ do not cancel exactly and the preconditioner is only approximately of the form (25), which is why an outer flexible Krylov method is advisable in that case.
+The cancellation that produces the fused grouping is algebraic only for a fixed linear operator; if the velocity `KSP` is an inexact Krylov method, the two solves with $\mathbf{A}$ do not cancel exactly and the preconditioner is only approximately of the form (17), which is why an outer flexible Krylov method is advisable in that case.
 
 The Schur block enters twice: as the **operator**, applied matrix-free as $\mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G}$ with $\mathbf{A}^{-1}$ supplied by the inner solve (`-fieldsplit_pressure_inner_`, which in PETSc falls back to the velocity solve), and as the **preconditioner** for that operator (`-pc_fieldsplit_schur_precondition`: `a11` for the $(1,1)$ block itself, `user` for a supplied matrix, `selfp` for the assembled $\mathbf{C} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{G}$). If the pressure `KSP` is iterated to a tight tolerance, $\widetilde{\mathbf{A}}_1$ is whatever the _inner_ solve applies and the preconditioner only affects the iteration count; if it is `preonly`, the preconditioner matrix alone defines $\widetilde{\mathbf{A}}_1$.
 

--- a/THEORY_GUIDE.md
+++ b/THEORY_GUIDE.md
@@ -10,6 +10,7 @@ This document presents the theoretical foundations and numerical methods impleme
 - [Spatial Discretization](#spatial-discretization)
 - [Immersed Boundary Method](#immersed-boundary-method)
 - [Segregated Solvers](#segregated-solvers)
+- [Coupled IMEX Formulation](#coupled-imex-formulation)
 
 ## Governing Equations
 
@@ -348,6 +349,200 @@ Comparing (18) with (16), the approximations to $\mathbf{A}$ are identified as:
 
 The continuity equation remains unperturbed.
 
+## Coupled IMEX Formulation
+
+Fluca's `Phys` module solves the incompressible equations as a fully coupled system in time. The semi-discretized equations are cast as a differential-algebraic system and advanced with an implicit-explicit (IMEX) Runge-Kutta integrator driving PETSc's `TS` directly. Unlike the segregated solvers above, the velocity-pressure coupling is retained and solved to convergence at every step; the classical pressure-velocity decoupling reappears here only as a family of _preconditioners_ for the coupled system, never as the time advancement itself.
+
+Three differences from the segregated notation should be noted, since several symbols are reused with new meanings.
+
+1. This formulation carries no separate face-normal unknown $U$: the Rhie-Chow interpolation is eliminated analytically and reappears as a cell-centered pressure-stabilization term, leaving a two-field system in $(\mathbf{u}, p)$.
+2. The pressure-gradient operators $\mathbf{G}$, $\mathbf{G}^\text{st}$ and the Rhie-Chow correction $\mathbf{R}$ are _unscaled_ here; the $\Delta t / \rho$ factor folded into them in the segregated chapter is written out explicitly below. The divergence $\mathbf{D}$ also changes meaning: it acts on the cell-centered velocity and carries a factor $\rho$, whereas the segregated $\mathbf{D}$ acts on the face-normal velocity $U$ and carries no $\rho$. Consequently $\sigma_0 = \Delta t$ alone, the $\rho$ having been absorbed into $\mathbf{D}$.
+3. $\mathbf{S}$ denotes the **pressure-stabilization** operator here, not the Schur complement it denotes in the segregated chapter. The Schur complement of this chapter is written $\widehat{\mathbf{S}}$, and its approximation $\widetilde{\mathbf{S}}$.
+
+### Pressure-Stabilized Semi-Discrete System
+
+Discretizing the momentum and continuity equations in space while leaving time continuous, and folding the Rhie-Chow correction into a cell-centered pressure-stabilization operator, yields for the cell-centered velocity $\mathbf{u}$ and pressure $p$:
+
+```math
+\rho \frac{d\mathbf{u}}{dt} + \mathbf{N}(\mathbf{u}) + \mathbf{G} p = \mu \mathbf{L} \mathbf{u} + \mathbf{f}(t) \tag{20}
+```
+
+```math
+\mathbf{D} \mathbf{u} + \sigma_0 \mathbf{S} p = 0 \tag{21}
+```
+
+where the discrete operators are
+
+- $\mathbf{N}$: convection, discretized with a second-order TVD scheme built on the face mass flux $\rho \overline{\mathbf{u}}$;
+- $\mathbf{G}$: cell-centered pressure gradient (unscaled);
+- $\mathbf{L}$: viscous Laplacian;
+- $\mathbf{D} = \rho \, \delta \overline{\mathbf{u}} / \delta x_i$: divergence of the interpolated velocity (carrying the factor $\rho$);
+- $\mathbf{S} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact}$: pressure stabilization, the difference between the wide (interpolated-gradient) and compact discrete Laplacians. It is the cell-centered form of the collocated Rhie-Chow correction [2], coupling pressure and velocity to suppress the checkerboard modes.
+
+The stabilization coefficient is $\sigma_0 = \Delta t$; since $\mathbf{D}$ already carries $\rho$, the effective coefficient relative to $\nabla \cdot \mathbf{u}$ is $\Delta t / \rho$, the classical Rhie-Chow coefficient [2].
+
+Because the continuity equation (21) contains no time derivative, the system is a **differential-algebraic equation** (DAE). Written as $\mathbf{M}\, d\mathbf{y}/dt = \dots$ with $\mathbf{y} = (\mathbf{u}, p)$, the mass matrix
+
+```math
+\mathbf{M} = \begin{bmatrix} \rho \mathbf{I} & 0 \\ 0 & 0 \end{bmatrix}
+```
+
+is singular: the pressure is an algebraic variable that instantaneously enforces stabilized incompressibility. The stabilization $\sigma_0 \mathbf{S}$ is what makes this constraint solvable on the collocated grid, by suppressing the checkerboard pressure modes.
+
+### Rhie-Chow Interpolation and Pressure Stabilization
+
+The stabilization operator $\mathbf{S}$ in Eq. (21) originates from the Rhie-Chow interpolation of the face-normal velocity, Eq. (7). Interpolating the cell-centered velocity to the faces directly would leave each cell pressure decoupled from its own gradient and admit checkerboard modes; instead the face-normal velocity carries a pressure-gradient correction:
+
+```math
+U = \overline{\mathbf{u}} \cdot \mathbf{n} + \frac{\Delta t}{\rho}\left( \overline{\nabla p} \cdot \mathbf{n} - \left. \frac{\partial p}{\partial n} \right|_\text{face} \right)
+```
+
+Here $\overline{(\cdot)}$ denotes linear interpolation from the two adjacent cell centers to the face. The first term is ordinary interpolation; the correction is the difference between the interpolated cell pressure gradient and the compact gradient evaluated directly at the face. Because the compact face gradient couples the two adjacent cell pressures, this correction removes the odd-even decoupling. Following Zang et al. [2], the coefficient is fixed at $\Delta t / \rho$ rather than taken from the momentum-equation diagonal as in the classical Rhie-Chow scheme.
+
+Reusing the interpolation operator $\mathbf{T}$ (cell velocity to face normal), and writing $\mathbf{G}$ and $\mathbf{G}^\text{st}$ for the _unscaled_ cell-centered and staggered face-normal pressure gradients — that is, $\mathbf{G}p = \delta p / \delta x_i$ and $\mathbf{G}^\text{st}p = \delta p / \delta n |_\text{face}$, without the $\Delta t / \rho$ carried by their segregated-chapter counterparts — the face velocity becomes
+
+```math
+U = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\left( \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \right) p = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\,\mathbf{R}\, p, \qquad \mathbf{R} = \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st}
+```
+
+which is Eq. (11) with the $\Delta t / \rho$ scaling written out. The discrete continuity equation is the divergence of these face-normal velocities; writing $\mathbf{D}_0$ for that divergence operator ($\mathbf{D}_0 U = \sum_i \delta U_i / \delta x_i$),
+
+```math
+\mathbf{D}_0 \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\, \mathbf{D}_0 \mathbf{R}\, p = 0
+```
+
+The two products in $\mathbf{D}_0\mathbf{R} = \mathbf{D}_0\mathbf{T}\mathbf{G} - \mathbf{D}_0\mathbf{G}^\text{st}$ are two discrete Laplacians of the pressure: $\mathbf{D}_0\mathbf{T}\mathbf{G}$ interpolates the cell gradient before differencing, a **wide** ($2\Delta x$-stencil) Laplacian, whereas $\mathbf{D}_0\mathbf{G}^\text{st}$ differences the compact face gradient, a **compact** (nearest-neighbor) Laplacian. Their difference is the stabilization operator:
+
+```math
+\mathbf{S} = \mathbf{D}_0\mathbf{R} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact}
+```
+
+Multiplying the continuity relation by $\rho$ and identifying the divergence of the interpolated velocity $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$ and $\sigma_0 = \Delta t$ recovers the stabilized constraint (21), $\mathbf{D}\mathbf{u} + \sigma_0 \mathbf{S} p = 0$. The stabilization $\sigma_0 \mathbf{S}$ is therefore the divergence of the Rhie-Chow correction. It vanishes to the order of the truncation error for smooth pressure fields — where the wide and compact Laplacians agree — and acts only on the under-resolved checkerboard modes, which is precisely the coupling required by the collocated grid.
+
+### IMEX Runge-Kutta Advancement
+
+`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{g}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{g}$ the non-stiff terms (advanced explicitly) [6]. PETSc's documentation calls the explicit part $\mathbf{G}$; it is renamed $\mathbf{g}$ here to avoid a collision with the pressure-gradient operator. The terms of (20)-(21) are sorted by stiffness:
+
+```math
+\mathbf{F} = \begin{bmatrix} \rho \dot{\mathbf{u}} - \mu \mathbf{L}\mathbf{u} + \mathbf{G} p \\ \mathbf{D}\mathbf{u} + \sigma_0 \mathbf{S} p \end{bmatrix}, \qquad
+\mathbf{g} = \begin{bmatrix} -\mathbf{N}(\mathbf{u}) + \mathbf{f}(t) \\ 0 \end{bmatrix}
+```
+
+The viscous term (parabolic-stiff), pressure gradient, and the algebraic continuity constraint are integrated implicitly; convection (non-stiff) is integrated explicitly. Keeping convection explicit leaves the implicit residual **linear** in $(\mathbf{u}, p)$, so each implicit stage is a single linear solve with no Newton iteration, at the cost of a convective CFL restriction.
+
+For an $s$-stage scheme with a diagonally-implicit tableau $a^I$, stage $i$ requires an implicit solve whose Jacobian is $\mathbf{J} = \text{shift}\cdot\mathbf{M} + \partial\mathbf{F}/\partial\mathbf{y}$, with the stage shift $\text{shift} = 1/(a^I_{ii}\,\Delta t)$:
+
+```math
+\mathbf{J} = \begin{bmatrix} \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix} \tag{22}
+```
+
+The singular pressure block of $\mathbf{M}$ contributes nothing to $\mathbf{J}$; the corresponding diagonal is instead supplied by the stabilization $\sigma_0 \mathbf{S}$, so $\mathbf{J}$ is nonsingular apart from the constant-pressure null space (removed by a null-space projection). A **stiffly-accurate** scheme (e.g. `ARKIMEX3`) is required so that the algebraic pressure is advanced at the full order of the method.
+
+### Schur-Complement Preconditioning
+
+The stage matrix (22) is a saddle-point system for the collocated two-field unknowns $(\mathbf{u}, p)$, in which the face-normal velocity has been eliminated and the Rhie-Chow correction absorbed into $\sigma_0 \mathbf{S}$. Writing $\mathbf{A} = \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L}$ and $\mathbf{C} = \sigma_0 \mathbf{S}$, it admits the block LDU factorization
+
+```math
+\mathbf{J} =
+\begin{bmatrix} \mathbf{I} & 0 \\ \mathbf{D}\mathbf{A}^{-1} & \mathbf{I} \end{bmatrix}
+\begin{bmatrix} \mathbf{A} & 0 \\ 0 & \widehat{\mathbf{S}} \end{bmatrix}
+\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix},
+\qquad \widehat{\mathbf{S}} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G} \tag{23}
+```
+
+Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\widehat{\mathbf{S}}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another. This is the two-field counterpart of the three-block decomposition (15) of the segregated solvers.
+
+#### Two independent approximations
+
+Following the nomenclature of Quarteroni et al. [7] as adopted by Elman et al. [4], group the lower and diagonal factors of (23) together, (LD)U:
+
+```math
+\mathbf{J} =
+\begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \widehat{\mathbf{S}} \end{bmatrix}
+\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix} \tag{24}
+```
+
+The $\mathbf{A}^{-1}$ of the lower factor cancels against the diagonal block, so exactly **two** occurrences of $\mathbf{A}^{-1}$ survive, and they are approximated independently:
+
+- $\widetilde{\mathbf{A}}_1$ — the approximation in the **Schur complement**, $\widetilde{\mathbf{S}} = \mathbf{C} - \mathbf{D}\widetilde{\mathbf{A}}_1^{-1}\mathbf{G}$, i.e. in the pressure-Poisson operator;
+- $\widetilde{\mathbf{A}}_2$ — the approximation in the **upper triangular factor**, i.e. in the velocity correction $\mathbf{u}^{n+1} = \mathbf{u}^* - \widetilde{\mathbf{A}}_2^{-1}\mathbf{G}p'$.
+
+These are the same two approximations identified in (16) for the segregated system. The resulting preconditioner — written $\widetilde{\mathbf{J}}$, since here it approximates the stage Jacobian $\mathbf{J}$ rather than the $\widetilde{\mathbf{M}}$ of the segregated chapter — and its error are
+
+```math
+\widetilde{\mathbf{J}} =
+\begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \widetilde{\mathbf{S}} \end{bmatrix}
+\begin{bmatrix} \mathbf{I} & \widetilde{\mathbf{A}}_2^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix},
+\qquad
+\mathbf{E} = \mathbf{J} - \widetilde{\mathbf{J}} =
+\begin{bmatrix}
+0 & (\mathbf{I} - \mathbf{A}\widetilde{\mathbf{A}}_2^{-1})\mathbf{G} \\
+0 & \mathbf{D}(\widetilde{\mathbf{A}}_1^{-1} - \widetilde{\mathbf{A}}_2^{-1})\mathbf{G}
+\end{bmatrix} \tag{25}
+```
+
+Reading off the two blocks of $\mathbf{E}$:
+
+1. The **momentum** equation is unperturbed iff $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ (_momentum preserving_) — only the pressure gradient seen by the velocity is affected, never the velocity operator itself.
+2. The **continuity** equation is unperturbed iff $\widetilde{\mathbf{A}}_1 = \widetilde{\mathbf{A}}_2$ (_mass preserving_) — the two approximations need not be accurate, only **consistent with each other**.
+
+Approximating the Schur complement alone is therefore _not_ what defines the fractional step method or SIMPLE. Both are mass-preserving schemes: they use the **same** cheap inverse in the Schur complement and in the velocity correction, and accept a perturbed momentum equation in exchange for an exactly satisfied discrete continuity equation. Keeping $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ while approximating only $\widetilde{\mathbf{A}}_1$ gives a different — momentum-preserving — member of the same family, in which continuity is the perturbed equation.
+
+| Scheme | $\widetilde{\mathbf{A}}_1$ | $\widetilde{\mathbf{A}}_2$ | Unperturbed |
+| --- | --- | --- | --- |
+| Exact block factorization | $\mathbf{A}$ | $\mathbf{A}$ | both |
+| Fractional step [5] | $\text{shift}\,\rho\,\mathbf{I}$ | $\text{shift}\,\rho\,\mathbf{I}$ | continuity |
+| SIMPLE [4] | $\operatorname{diag}(\mathbf{A})$ | $\operatorname{diag}(\mathbf{A})$ | continuity |
+| Schur-only approximation | $\ne \mathbf{A}$ | $\mathbf{A}$ | momentum |
+
+The fractional-step and SIMPLE choices coincide as $\Delta t \to 0$, where $\operatorname{diag}(\mathbf{A})$ is dominated by the mass term $\text{shift}\,\rho$. Because the split preconditions an outer Krylov iteration, the fully coupled solution is recovered independently of the choice; only the iteration count differs.
+
+#### Mapping onto `PCFIELDSPLIT`
+
+`PCFIELDSPLIT` implements exactly this taxonomy — its internal solver for the upper factor is named after $H_2$ of [4]. The solves and the Schur preconditioner matrix are set independently from the options database:
+
+| Role | Options prefix | Fluca default |
+| --- | --- | --- |
+| Solve with $\mathbf{A}$ (predictor, lower/diagonal factor) | `-fieldsplit_velocity_` | user-selected |
+| $\widetilde{\mathbf{A}}_1$ in $\widetilde{\mathbf{S}}$ | `-fieldsplit_pressure_inner_` | PETSc default: falls back to the velocity solve |
+| Preconditioner matrix for the Schur block | `-pc_fieldsplit_schur_precondition` | PETSc default: $\mathbf{A}_{11} = \sigma_0\mathbf{S}$ |
+| $\widetilde{\mathbf{A}}_2$ in the velocity correction | `-fieldsplit_pressure_upper_` | PETSc default: reuses the velocity solve |
+
+Only one prefix appears for the lower and diagonal factors because `PCFIELDSPLIT`, although it documents the `full` factorization as the plain LDU product, applies it in the fused (LD)U grouping of (24): a single solve with $\mathbf{A}$ produces both the predicted velocity and the argument of $\mathbf{D}\mathbf{u}^*$ that forms the Schur right-hand side. Each preconditioner application therefore costs **two** solves with $\mathbf{A}$ — the predictor and the velocity correction — rather than the three a literal L·D·U application would require.
+
+Note that the second solve does not disappear when $\widetilde{\mathbf{A}}_2$ is a cheap approximation. When a separate upper solver is configured (`kspUpper != kspA` in `PCApply_FieldSplit_Schur`), PETSc recomputes the predictor with $\mathbf{A}$ before applying $\widetilde{\mathbf{A}}_2^{-1}$, so the exact $\mathbf{A}$-solve count stays at two and only the *correction* becomes cheap. The saving from a cheap $\widetilde{\mathbf{A}}_2$ is in the correction, not in the predictor count.
+
+The cancellation that produces the fused grouping is algebraic only for a fixed linear operator; if the velocity `KSP` is an inexact Krylov method, the two solves with $\mathbf{A}$ do not cancel exactly and the preconditioner is only approximately of the form (25), which is why an outer flexible Krylov method is advisable in that case.
+
+The Schur block enters twice: as the **operator**, applied matrix-free as $\mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G}$ with $\mathbf{A}^{-1}$ supplied by the inner solve (`-fieldsplit_pressure_inner_`, which in PETSc falls back to the velocity solve), and as the **preconditioner** for that operator (`-pc_fieldsplit_schur_precondition`: `a11` for the $(1,1)$ block itself, `user` for a supplied matrix, `selfp` for the assembled $\mathbf{C} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{G}$). If the pressure `KSP` is iterated to a tight tolerance, $\widetilde{\mathbf{A}}_1$ is whatever the _inner_ solve applies and the preconditioner only affects the iteration count; if it is `preonly`, the preconditioner matrix alone defines $\widetilde{\mathbf{A}}_1$.
+
+One PETSc behavior is worth knowing when relying on the fallback: if no separate inner solver is configured, `PCFIELDSPLIT` sets the velocity `KSP` type to `gmres`, overriding the `preonly` that `PCFieldSplitSetIS` installs, so that the $\mathbf{A}^{-1}$ inside the matrix-free Schur complement is an accurate solve rather than a single preconditioner application. This happens before the velocity `KSP` reads its own options, so `-fieldsplit_velocity_ksp_type` still takes precedence — but leaving it unset does not give a `preonly` velocity solve.
+
+#### Fluca's default
+
+Fluca installs the split itself — `PCFIELDSPLIT` of type Schur with `PC_FIELDSPLIT_SCHUR_FACT_FULL`, the velocity and pressure index sets, and the pressure null space — but approximates neither $\widetilde{\mathbf{A}}_1$ nor $\widetilde{\mathbf{A}}_2$. Both fall back to PETSc's default, the velocity solve, so the default sits in the **first** row of the table above: $\widetilde{\mathbf{A}}_1 = \widetilde{\mathbf{A}}_2 = \mathbf{A}$, perturbing neither momentum nor continuity. All three solves, and the choice of Schur preconditioner matrix, are left to the options database.
+
+Because the split is installed before `TSSetFromOptions` runs, `PCFIELDSPLIT` already has its composite type set to Schur when `PCSetFromOptions` executes, so the `-pc_fieldsplit_schur_*` options are read normally and no special replay is needed.
+
+The Schur preconditioner matrix is therefore PETSc's default, $\mathbf{A}_{11} = \sigma_0\mathbf{S}$. This is the stabilization operator alone, which acts on the checkerboard modes and is a weak preconditioner for the smooth ones. The `selfp` alternative, the explicitly assembled
+
+```math
+\mathbf{S}_p = \sigma_0\mathbf{S} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{G}
+```
+
+carries the $\mathbf{D}\mathbf{A}^{-1}\mathbf{G}$ term as well and so covers all pressure modes; it is selected with `-pc_fieldsplit_schur_precondition selfp`.
+
+Note that `selfp` is a choice of preconditioner, not of approximation, and it does **not** by itself make the solver SIMPLE. $\widetilde{\mathbf{A}}_1$ is still whatever the _inner_ solve applies, so with the pressure `KSP` converged to a tight tolerance the classification above is unchanged and $\mathbf{S}_p$ only lowers the iteration count. Only under `-fieldsplit_pressure_ksp_type preonly` does the preconditioner matrix itself become $\widetilde{\mathbf{A}}_1$, giving $\widetilde{\mathbf{A}}_1 = \operatorname{diag}(\mathbf{A})$ against $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ — the momentum-preserving last row, not SIMPLE. SIMPLE additionally requires $\widetilde{\mathbf{A}}_2 = \operatorname{diag}(\mathbf{A})$ through `-fieldsplit_pressure_upper_`.
+
+Because nothing is baked into the operators, the Jacobian is untouched: $\mathbf{P}_\text{mat} = \mathbf{A}_\text{mat} = \mathbf{J}$, and `-ksp_type preonly -pc_type lu -pc_factor_shift_type nonzero` remains an exact monolithic reference solve. The shift is required: the $(2,2)$ block is $\sigma_0\mathbf{S}$, which is singular on the constant-pressure mode, so an unshifted `LU` hits a zero pivot and the step fails. The cheaper members of the family are reachable entirely from the options database — for example SIMPLE:
+
+```
+-pc_fieldsplit_schur_precondition selfp
+-fieldsplit_pressure_mat_schur_complement_ainv_type diag   # A1 = diag(A) in the assembled S
+-fieldsplit_pressure_inner_ksp_type preonly -fieldsplit_pressure_inner_pc_type jacobi
+-fieldsplit_pressure_upper_ksp_type preonly -fieldsplit_pressure_upper_pc_type jacobi   # A2 = diag(A)
+```
+
 ## References
 
 1. D. Kim and H. Choi, A Second-Order Time-Accurate Finite Volume Method for Unsteady Incompressible Flow on Hybrid Unstructured Grids, _J. Comput. Phys._, 162, 411&ndash;428 (2000).
@@ -355,3 +550,5 @@ The continuity equation remains unperturbed.
 3. S. Armfield and R. Street, The pressure accuracy of fractional-step methods for the Navier-Stokes equations on staggered grids, _ANZIAM J._, 44, C20&ndash;C39 (2003).
 4. H. Elman, V. E. Howle, J. Shadid, R. Shuttleworth, and R. Tuminaro, A taxonomy and comparison of parallel block multi-level preconditioners for the incompressible Navier–Stokes equations, _J. Comput. Phys._, 227, 1790&ndash;1808 (2008)
 5. J. Perot, An analysis of the fractional step method, _J. Comput. Phys._, 108, 51&ndash;58 (1993).
+6. U. M. Ascher, S. J. Ruuth, and R. J. Spiteri, Implicit-explicit Runge-Kutta methods for time-dependent partial differential equations, _Appl. Numer. Math._, 25, 151&ndash;167 (1997).
+7. A. Quarteroni, F. Saleri, and A. Veneziani, Factorization methods for the numerical approximation of Navier&ndash;Stokes equations, _Comput. Methods Appl. Mech. Engrg._, 188, 505&ndash;526 (2000).

--- a/THEORY_GUIDE.md
+++ b/THEORY_GUIDE.md
@@ -140,18 +140,18 @@ The spatial operators are:
 
 - $\mathbf{N}(\mathbf{u})$: convection, discretized with a second-order TVD scheme built on the face mass flux $\rho\overline{\mathbf{u}}$;
 - $\mathbf{L}$: viscous Laplacian, $(\mathbf{L}\mathbf{u})_i = \delta^2 u_i / \delta x_j \delta x_j$;
-- $\mathbf{G}$: cell-centered pressure gradient, $(\mathbf{G}p)_i = \delta p / \delta x_i$;
+- $\mathbf{B}^\top$: cell-centered pressure gradient, $(\mathbf{B}^\top p)_i = \delta p / \delta x_i$. The symbol follows the saddle-point convention of Elman et al. [4] and Quarteroni et al. [7], in which $\mathbf{B}$ is the discrete divergence and $\mathbf{B}^\top$ the discrete gradient. The transpose is genuine here up to sign: the assembled blocks satisfy $\mathbf{D} = -\mathbf{B}$ exactly on every interior row, which is the discrete integration-by-parts identity $\langle \mathbf{B}^\top p, \mathbf{u}\rangle = -\langle p, \mathbf{B}\mathbf{u}\rangle$. It is not exact on boundary rows, where the velocity Dirichlet conditions imposed on $\mathbf{D}$ and the pressure Neumann conditions imposed on $\mathbf{B}^\top$ are not adjoint to one another; under periodic boundaries, which have no such rows, the identity holds everywhere;
 - $\mathbf{T}$: interpolation of a cell-centered vector to the face normal, $\mathbf{T}\mathbf{v} = \overline{\mathbf{v}} \cdot \mathbf{n}$, where $\overline{(\cdot)}$ denotes linear interpolation from the two adjacent cell centers;
-- $\mathbf{G}^\text{st}$: staggered face-normal pressure gradient, evaluated compactly at the face, $\mathbf{G}^\text{st}p = \left. \delta p / \delta n \right|_\text{face}$;
-- $\mathbf{D}_0$: divergence of a face-normal field, $\mathbf{D}_0 U = \sum_i \delta U_i / \delta x_i$;
-- $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$: divergence of the interpolated velocity, carrying the factor $\rho$.
+- $\mathbf{B}^\top_\text{st}$: staggered face-normal pressure gradient, evaluated compactly at the face, $\mathbf{B}^\top_\text{st}\, p = \left. \delta p / \delta n \right|_\text{face}$;
+- $\mathbf{D}_\text{st}$: staggered divergence, acting on a face-normal field, $\mathbf{D}_\text{st} U = \sum_i \delta U_i / \delta x_i$;
+- $\mathbf{D} = \mathbf{D}_\text{st}\mathbf{T}$: divergence of the interpolated velocity.
 
 ### Momentum Equation
 
 Discretizing the momentum equation (2) in space while leaving time continuous gives, for the cell-centered velocity $\mathbf{u}$ and pressure $p$:
 
 ```math
-\rho \frac{d\mathbf{u}}{dt} + \mathbf{N}(\mathbf{u}) + \mathbf{G} p = \mu \mathbf{L} \mathbf{u} + \mathbf{f}(t) \tag{9}
+\rho \frac{d\mathbf{u}}{dt} + \mathbf{N}(\mathbf{u}) + \mathbf{B}^\top p = \mu \mathbf{L} \mathbf{u} + \mathbf{f}(t) \tag{9}
 ```
 
 where $\mathbf{f}$ collects body forces and the boundary-condition contributions of the viscous and pressure operators.
@@ -161,37 +161,37 @@ where $\mathbf{f}$ collects body forces and the boundary-condition contributions
 The face-normal velocity is not an independent unknown: it is the derived quantity supplied by the Rhie-Chow interpolation (7). Interpolating the cell-centered velocity to the faces directly would leave each cell pressure decoupled from its own gradient and admit checkerboard modes; the interpolation therefore carries a pressure-gradient correction. In operator form,
 
 ```math
-U = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\left( \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \right) p = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\,\mathbf{R}\, p, \qquad \mathbf{R} = \mathbf{T}\mathbf{G} - \mathbf{G}^\text{st} \tag{10}
+U = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\left( \mathbf{T}\mathbf{B}^\top - \mathbf{B}^\top_\text{st} \right) p = \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\,\mathbf{R}\, p, \qquad \mathbf{R} = \mathbf{T}\mathbf{B}^\top - \mathbf{B}^\top_\text{st} \tag{10}
 ```
 
 where $\mathbf{R}$ is the Rhie-Chow correction operator: the difference between the interpolated cell pressure gradient and the compact gradient evaluated directly at the face. Because the compact face gradient couples the two adjacent cell pressures, this correction removes the odd-even decoupling. Following Zang et al. [2], the coefficient is fixed at $\Delta t / \rho$ rather than taken from the momentum-equation diagonal as in the classical Rhie-Chow scheme.
 
-The discrete continuity equation is the vanishing divergence of these face-normal velocities, $\mathbf{D}_0 U = 0$, which on substituting (10) becomes
+The discrete continuity equation is the vanishing divergence of these face-normal velocities, $\mathbf{D}_\text{st} U = 0$, which on substituting (10) becomes
 
 ```math
-\mathbf{D}_0 \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\, \mathbf{D}_0 \mathbf{R}\, p = 0
+\mathbf{D}_\text{st} \mathbf{T}\mathbf{u} + \frac{\Delta t}{\rho}\, \mathbf{D}_\text{st} \mathbf{R}\, p = 0
 ```
 
-The two products in $\mathbf{D}_0\mathbf{R} = \mathbf{D}_0\mathbf{T}\mathbf{G} - \mathbf{D}_0\mathbf{G}^\text{st}$ are two discrete Laplacians of the pressure: $\mathbf{D}_0\mathbf{T}\mathbf{G}$ interpolates the cell gradient before differencing, a **wide** ($2\Delta x$-stencil) Laplacian, whereas $\mathbf{D}_0\mathbf{G}^\text{st}$ differences the compact face gradient, a **compact** (nearest-neighbor) Laplacian. Their difference defines the pressure-stabilization operator:
+The two products in $\mathbf{D}_\text{st}\mathbf{R} = \mathbf{D}_\text{st}\mathbf{T}\mathbf{B}^\top - \mathbf{D}_\text{st}\mathbf{B}^\top_\text{st}$ are two discrete Laplacians of the pressure: $\mathbf{D}_\text{st}\mathbf{T}\mathbf{B}^\top$ interpolates the cell gradient before differencing, a **wide** ($2\Delta x$-stencil) Laplacian, whereas $\mathbf{D}_\text{st}\mathbf{B}^\top_\text{st}$ differences the compact face gradient, a **compact** (nearest-neighbor) Laplacian. Their difference is the pressure stabilization. Identifying $\mathbf{D} = \mathbf{D}_\text{st}\mathbf{T}$ and absorbing the factor $\Delta t / \rho$ into the operator gives the stabilization block
 
 ```math
-\mathbf{S} = \mathbf{D}_0\mathbf{R} = \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact} \tag{11}
+\mathbf{C} = \frac{\Delta t}{\rho}\, \mathbf{D}_\text{st}\mathbf{R} = \frac{\Delta t}{\rho} \left( \mathbf{L}^\text{wide} - \mathbf{L}^\text{compact} \right) \tag{11}
 ```
 
-Multiplying through by $\rho$ and identifying $\mathbf{D} = \rho\,\mathbf{D}_0\mathbf{T}$ and the stabilization coefficient $\sigma_0 = \Delta t$ gives the stabilized continuity constraint in cell-centered form:
+and with it the stabilized continuity constraint in cell-centered form:
 
 ```math
-\mathbf{D} \mathbf{u} + \sigma_0 \mathbf{S} p = 0 \tag{12}
+\mathbf{D} \mathbf{u} + \mathbf{C} p = 0 \tag{12}
 ```
 
-Since $\mathbf{D}$ already carries $\rho$, the effective coefficient relative to $\nabla \cdot \mathbf{u}$ is $\Delta t / \rho$, the classical Rhie-Chow coefficient [2]. The stabilization $\sigma_0 \mathbf{S}$ is therefore nothing but the divergence of the Rhie-Chow correction, written as a cell-centered pressure operator. It vanishes to the order of the truncation error for smooth pressure fields — where the wide and compact Laplacians agree — and acts only on the under-resolved checkerboard modes, which is precisely the coupling the collocated grid requires. Because $U$ has been eliminated, the discrete system carries only the two cell-centered fields $(\mathbf{u}, p)$.
+The coefficient $\Delta t / \rho$ is not a free stabilization parameter: it is the classical Rhie-Chow coefficient [2], inherited unchanged from the interpolation (10). The stabilization $\mathbf{C}$ is therefore nothing but the divergence of the Rhie-Chow correction, written as a cell-centered pressure operator. It vanishes to the order of the truncation error for smooth pressure fields — where the wide and compact Laplacians agree — and acts only on the under-resolved checkerboard modes, which is precisely the coupling the collocated grid requires. Because $U$ has been eliminated, the discrete system carries only the two cell-centered fields $(\mathbf{u}, p)$.
 
 ### Saddle-Point Structure
 
 Any implicit time discretization of (9) turns the velocity terms into a single velocity block $\mathbf{A}$ acting on the new-time velocity, leaving the pressure gradient, the constraint (12), and known right-hand-side data. The result is the two-field saddle-point system
 
 ```math
-\begin{bmatrix} \mathbf{A} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix}
+\begin{bmatrix} \mathbf{A} & \mathbf{B}^\top \\ \mathbf{D} & \mathbf{C} \end{bmatrix}
 \begin{bmatrix} \mathbf{u} \\ p \end{bmatrix} =
 \begin{bmatrix} \mathbf{r} + \mathbf{b}_\text{mom} \\ b_\text{cont} \end{bmatrix} \tag{13}
 ```
@@ -206,7 +206,7 @@ The matrix in (13) is large, sparse, and indefinite: the $(2,2)$ block is not th
 
 Fluca's `Phys` module solves the incompressible equations as a fully coupled system in time. The semi-discrete system (9), (12) is cast as a differential-algebraic system and advanced with an implicit-explicit (IMEX) Runge-Kutta integrator driving PETSc's `TS` directly. The velocity-pressure coupling is retained and solved to convergence at every step; the classical pressure-velocity decoupling reappears here only as a family of _preconditioners_ for the coupled system, never as the time advancement itself.
 
-The discrete operators of the previous chapter are used unchanged, and the stage matrix is the saddle-point system (13). The only new symbols are the Schur complement $\widehat{\mathbf{S}}$ and its approximation $\widetilde{\mathbf{S}}$, both distinct from the pressure-stabilization operator $\mathbf{S}$ of (11).
+The discrete operators of the previous chapter are used unchanged, and the stage matrix is the saddle-point system (13). The only new symbols are the Schur complement $\mathbf{S}$ and its approximation $\widetilde{\mathbf{S}}$.
 
 ### Differential-Algebraic Structure
 
@@ -216,15 +216,15 @@ Because the stabilized continuity constraint (12) contains no time derivative, t
 \mathbf{M} = \begin{bmatrix} \rho \mathbf{I} & 0 \\ 0 & 0 \end{bmatrix}
 ```
 
-is singular: the pressure is an algebraic variable that instantaneously enforces stabilized incompressibility. The stabilization $\sigma_0 \mathbf{S}$ is what makes this constraint solvable on the collocated grid, by suppressing the checkerboard pressure modes.
+is singular: the pressure is an algebraic variable that instantaneously enforces stabilized incompressibility. The stabilization $\mathbf{C}$ is what makes this constraint solvable on the collocated grid, by suppressing the checkerboard pressure modes.
 
 ### IMEX Runge-Kutta Advancement
 
-`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{g}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{g}$ the non-stiff terms (advanced explicitly) [6]. PETSc's documentation calls the explicit part $\mathbf{G}$; it is renamed $\mathbf{g}$ here to avoid a collision with the pressure-gradient operator. The terms of (9) and (12) are sorted by stiffness:
+`TSARKIMEX` solves systems of the form $\mathbf{F}(t, \mathbf{y}, \dot{\mathbf{y}}) = \mathbf{G}(t, \mathbf{y})$, where $\mathbf{F}$ collects the stiff terms (advanced implicitly) and $\mathbf{G}$ the non-stiff terms (advanced explicitly) [6]. The terms of (9) and (12) are sorted by stiffness:
 
 ```math
-\mathbf{F} = \begin{bmatrix} \rho \dot{\mathbf{u}} - \mu \mathbf{L}\mathbf{u} + \mathbf{G} p \\ \mathbf{D}\mathbf{u} + \sigma_0 \mathbf{S} p \end{bmatrix}, \qquad
-\mathbf{g} = \begin{bmatrix} -\mathbf{N}(\mathbf{u}) + \mathbf{f}(t) \\ 0 \end{bmatrix}
+\mathbf{F} = \begin{bmatrix} \rho \dot{\mathbf{u}} - \mu \mathbf{L}\mathbf{u} + \mathbf{B}^\top p \\ \mathbf{D}\mathbf{u} + \mathbf{C} p \end{bmatrix}, \qquad
+\mathbf{G} = \begin{bmatrix} -\mathbf{N}(\mathbf{u}) + \mathbf{f}(t) \\ 0 \end{bmatrix}
 ```
 
 The viscous term (parabolic-stiff), pressure gradient, and the algebraic continuity constraint are integrated implicitly; convection (non-stiff) is integrated explicitly. Keeping convection explicit leaves the implicit residual **linear** in $(\mathbf{u}, p)$, so each implicit stage is a single linear solve with no Newton iteration, at the cost of a convective CFL restriction.
@@ -232,24 +232,24 @@ The viscous term (parabolic-stiff), pressure gradient, and the algebraic continu
 For an $s$-stage scheme with a diagonally-implicit tableau $a^I$, stage $i$ requires an implicit solve whose Jacobian is $\mathbf{J} = \text{shift}\cdot\mathbf{M} + \partial\mathbf{F}/\partial\mathbf{y}$, with the stage shift $\text{shift} = 1/(a^I_{ii}\,\Delta t)$:
 
 ```math
-\mathbf{J} = \begin{bmatrix} \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L} & \mathbf{G} \\ \mathbf{D} & \sigma_0 \mathbf{S} \end{bmatrix} \tag{14}
+\mathbf{J} = \begin{bmatrix} \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L} & \mathbf{B}^\top \\ \mathbf{D} & \mathbf{C} \end{bmatrix} \tag{14}
 ```
 
-The singular pressure block of $\mathbf{M}$ contributes nothing to $\mathbf{J}$; the corresponding diagonal is instead supplied by the stabilization $\sigma_0 \mathbf{S}$, so $\mathbf{J}$ is nonsingular apart from the constant-pressure null space (removed by a null-space projection). A **stiffly-accurate** scheme (e.g. `ARKIMEX3`) is required so that the algebraic pressure is advanced at the full order of the method.
+The singular pressure block of $\mathbf{M}$ contributes nothing to $\mathbf{J}$; the corresponding diagonal is instead supplied by the stabilization $\mathbf{C}$, so $\mathbf{J}$ is nonsingular apart from the constant-pressure null space (removed by a null-space projection). A **stiffly-accurate** scheme (e.g. `ARKIMEX3`) is required so that the algebraic pressure is advanced at the full order of the method.
 
 ### Schur-Complement Preconditioning
 
-The stage matrix (14) is the saddle-point system (13) with the velocity block $\mathbf{A} = \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L}$ supplied by the IMEX stage. Abbreviating the stabilized $(2,2)$ block as $\mathbf{C} = \sigma_0 \mathbf{S}$, it admits the block LDU factorization
+The stage matrix (14) is the saddle-point system (13) with the velocity block $\mathbf{A} = \text{shift}\,\rho \mathbf{I} - \mu \mathbf{L}$ supplied by the IMEX stage. It admits the block LDU factorization
 
 ```math
 \mathbf{J} =
 \begin{bmatrix} \mathbf{I} & 0 \\ \mathbf{D}\mathbf{A}^{-1} & \mathbf{I} \end{bmatrix}
-\begin{bmatrix} \mathbf{A} & 0 \\ 0 & \widehat{\mathbf{S}} \end{bmatrix}
-\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix},
-\qquad \widehat{\mathbf{S}} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G} \tag{15}
+\begin{bmatrix} \mathbf{A} & 0 \\ 0 & \mathbf{S} \end{bmatrix}
+\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{B}^\top \\ 0 & \mathbf{I} \end{bmatrix},
+\qquad \mathbf{S} = \mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{B}^\top \tag{15}
 ```
 
-Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\widehat{\mathbf{S}}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another.
+Fluca applies this factorization as a preconditioner via `PCFIELDSPLIT` of type Schur with full factorization. The two triangular factors are the momentum **predictor** and velocity **corrector**, and the middle factor is the **pressure-Poisson** solve (with the Schur complement $\mathbf{S}$) — the classical fractional-step sweep, now used to precondition rather than to time-advance. Perot [5] showed that the fractional step method is itself such an approximate block factorization, and Elman et al. [4] that SIMPLE is another.
 
 #### Two independent approximations
 
@@ -257,26 +257,26 @@ Following the nomenclature of Quarteroni et al. [7] as adopted by Elman et al. [
 
 ```math
 \mathbf{J} =
-\begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \widehat{\mathbf{S}} \end{bmatrix}
-\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix} \tag{16}
+\begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \mathbf{S} \end{bmatrix}
+\begin{bmatrix} \mathbf{I} & \mathbf{A}^{-1}\mathbf{B}^\top \\ 0 & \mathbf{I} \end{bmatrix} \tag{16}
 ```
 
 The $\mathbf{A}^{-1}$ of the lower factor cancels against the diagonal block, so exactly **two** occurrences of $\mathbf{A}^{-1}$ survive, and they are approximated independently:
 
-- $\widetilde{\mathbf{A}}_1$ — the approximation in the **Schur complement**, $\widetilde{\mathbf{S}} = \mathbf{C} - \mathbf{D}\widetilde{\mathbf{A}}_1^{-1}\mathbf{G}$, i.e. in the pressure-Poisson operator;
-- $\widetilde{\mathbf{A}}_2$ — the approximation in the **upper triangular factor**, i.e. in the velocity correction $\mathbf{u}^{n+1} = \mathbf{u}^* - \widetilde{\mathbf{A}}_2^{-1}\mathbf{G}p'$.
+- $\widetilde{\mathbf{A}}_1$ — the approximation in the **Schur complement**, $\widetilde{\mathbf{S}} = \mathbf{C} - \mathbf{D}\widetilde{\mathbf{A}}_1^{-1}\mathbf{B}^\top$, i.e. in the pressure-Poisson operator;
+- $\widetilde{\mathbf{A}}_2$ — the approximation in the **upper triangular factor**, i.e. in the velocity correction $\mathbf{u}^{n+1} = \mathbf{u}^* - \widetilde{\mathbf{A}}_2^{-1}\mathbf{B}^\top p'$.
 
 The resulting preconditioner $\widetilde{\mathbf{J}}$ and its error are
 
 ```math
 \widetilde{\mathbf{J}} =
 \begin{bmatrix} \mathbf{A} & 0 \\ \mathbf{D} & \widetilde{\mathbf{S}} \end{bmatrix}
-\begin{bmatrix} \mathbf{I} & \widetilde{\mathbf{A}}_2^{-1}\mathbf{G} \\ 0 & \mathbf{I} \end{bmatrix},
+\begin{bmatrix} \mathbf{I} & \widetilde{\mathbf{A}}_2^{-1}\mathbf{B}^\top \\ 0 & \mathbf{I} \end{bmatrix},
 \qquad
 \mathbf{E} = \mathbf{J} - \widetilde{\mathbf{J}} =
 \begin{bmatrix}
-0 & (\mathbf{I} - \mathbf{A}\widetilde{\mathbf{A}}_2^{-1})\mathbf{G} \\
-0 & \mathbf{D}(\widetilde{\mathbf{A}}_1^{-1} - \widetilde{\mathbf{A}}_2^{-1})\mathbf{G}
+0 & (\mathbf{I} - \mathbf{A}\widetilde{\mathbf{A}}_2^{-1})\mathbf{B}^\top \\
+0 & \mathbf{D}(\widetilde{\mathbf{A}}_1^{-1} - \widetilde{\mathbf{A}}_2^{-1})\mathbf{B}^\top
 \end{bmatrix} \tag{17}
 ```
 
@@ -304,7 +304,7 @@ The fractional-step and SIMPLE choices coincide as $\Delta t \to 0$, where $\ope
 | --- | --- | --- |
 | Solve with $\mathbf{A}$ (predictor, lower/diagonal factor) | `-fieldsplit_velocity_` | user-selected |
 | $\widetilde{\mathbf{A}}_1$ in $\widetilde{\mathbf{S}}$ | `-fieldsplit_pressure_inner_` | PETSc default: falls back to the velocity solve |
-| Preconditioner matrix for the Schur block | `-pc_fieldsplit_schur_precondition` | PETSc default: $\mathbf{A}_{11} = \sigma_0\mathbf{S}$ |
+| Preconditioner matrix for the Schur block | `-pc_fieldsplit_schur_precondition` | PETSc default: $\mathbf{A}_{11} = \mathbf{C}$ |
 | $\widetilde{\mathbf{A}}_2$ in the velocity correction | `-fieldsplit_pressure_upper_` | PETSc default: reuses the velocity solve |
 
 Only one prefix appears for the lower and diagonal factors because `PCFIELDSPLIT`, although it documents the `full` factorization as the plain LDU product, applies it in the fused (LD)U grouping of (16): a single solve with $\mathbf{A}$ produces both the predicted velocity and the argument of $\mathbf{D}\mathbf{u}^*$ that forms the Schur right-hand side. Each preconditioner application therefore costs **two** solves with $\mathbf{A}$ — the predictor and the velocity correction — rather than the three a literal L·D·U application would require.
@@ -313,7 +313,7 @@ Note that the second solve does not disappear when $\widetilde{\mathbf{A}}_2$ is
 
 The cancellation that produces the fused grouping is algebraic only for a fixed linear operator; if the velocity `KSP` is an inexact Krylov method, the two solves with $\mathbf{A}$ do not cancel exactly and the preconditioner is only approximately of the form (17), which is why an outer flexible Krylov method is advisable in that case.
 
-The Schur block enters twice: as the **operator**, applied matrix-free as $\mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{G}$ with $\mathbf{A}^{-1}$ supplied by the inner solve (`-fieldsplit_pressure_inner_`, which in PETSc falls back to the velocity solve), and as the **preconditioner** for that operator (`-pc_fieldsplit_schur_precondition`: `a11` for the $(1,1)$ block itself, `user` for a supplied matrix, `selfp` for the assembled $\mathbf{C} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{G}$). If the pressure `KSP` is iterated to a tight tolerance, $\widetilde{\mathbf{A}}_1$ is whatever the _inner_ solve applies and the preconditioner only affects the iteration count; if it is `preonly`, the preconditioner matrix alone defines $\widetilde{\mathbf{A}}_1$.
+The Schur block enters twice: as the **operator**, applied matrix-free as $\mathbf{C} - \mathbf{D}\mathbf{A}^{-1}\mathbf{B}^\top$ with $\mathbf{A}^{-1}$ supplied by the inner solve (`-fieldsplit_pressure_inner_`, which in PETSc falls back to the velocity solve), and as the **preconditioner** for that operator (`-pc_fieldsplit_schur_precondition`: `a11` for the $(1,1)$ block itself, `user` for a supplied matrix, `selfp` for the assembled $\mathbf{C} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{B}^\top$). If the pressure `KSP` is iterated to a tight tolerance, $\widetilde{\mathbf{A}}_1$ is whatever the _inner_ solve applies and the preconditioner only affects the iteration count; if it is `preonly`, the preconditioner matrix alone defines $\widetilde{\mathbf{A}}_1$.
 
 One PETSc behavior is worth knowing when relying on the fallback: if no separate inner solver is configured, `PCFIELDSPLIT` sets the velocity `KSP` type to `gmres`, overriding the `preonly` that `PCFieldSplitSetIS` installs, so that the $\mathbf{A}^{-1}$ inside the matrix-free Schur complement is an accurate solve rather than a single preconditioner application. This happens before the velocity `KSP` reads its own options, so `-fieldsplit_velocity_ksp_type` still takes precedence — but leaving it unset does not give a `preonly` velocity solve.
 
@@ -323,17 +323,17 @@ Fluca installs the split itself — `PCFIELDSPLIT` of type Schur with `PC_FIELDS
 
 Because the split is installed before `TSSetFromOptions` runs, `PCFIELDSPLIT` already has its composite type set to Schur when `PCSetFromOptions` executes, so the `-pc_fieldsplit_schur_*` options are read normally and no special replay is needed.
 
-The Schur preconditioner matrix is therefore PETSc's default, $\mathbf{A}_{11} = \sigma_0\mathbf{S}$. This is the stabilization operator alone, which acts on the checkerboard modes and is a weak preconditioner for the smooth ones. The `selfp` alternative, the explicitly assembled
+The Schur preconditioner matrix is therefore PETSc's default, $\mathbf{A}_{11} = \mathbf{C}$. This is the stabilization operator alone, which acts on the checkerboard modes and is a weak preconditioner for the smooth ones. The `selfp` alternative, the explicitly assembled
 
 ```math
-\mathbf{S}_p = \sigma_0\mathbf{S} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{G}
+\mathbf{S}_p = \mathbf{C} - \mathbf{D}\operatorname{diag}(\mathbf{A})^{-1}\mathbf{B}^\top
 ```
 
-carries the $\mathbf{D}\mathbf{A}^{-1}\mathbf{G}$ term as well and so covers all pressure modes; it is selected with `-pc_fieldsplit_schur_precondition selfp`.
+carries the $\mathbf{D}\mathbf{A}^{-1}\mathbf{B}^\top$ term as well and so covers all pressure modes; it is selected with `-pc_fieldsplit_schur_precondition selfp`.
 
 Note that `selfp` is a choice of preconditioner, not of approximation, and it does **not** by itself make the solver SIMPLE. $\widetilde{\mathbf{A}}_1$ is still whatever the _inner_ solve applies, so with the pressure `KSP` converged to a tight tolerance the classification above is unchanged and $\mathbf{S}_p$ only lowers the iteration count. Only under `-fieldsplit_pressure_ksp_type preonly` does the preconditioner matrix itself become $\widetilde{\mathbf{A}}_1$, giving $\widetilde{\mathbf{A}}_1 = \operatorname{diag}(\mathbf{A})$ against $\widetilde{\mathbf{A}}_2 = \mathbf{A}$ — the momentum-preserving last row, not SIMPLE. SIMPLE additionally requires $\widetilde{\mathbf{A}}_2 = \operatorname{diag}(\mathbf{A})$ through `-fieldsplit_pressure_upper_`.
 
-Because nothing is baked into the operators, the Jacobian is untouched: $\mathbf{P}_\text{mat} = \mathbf{A}_\text{mat} = \mathbf{J}$, and `-ksp_type preonly -pc_type lu -pc_factor_shift_type nonzero` remains an exact monolithic reference solve. The shift is required: the $(2,2)$ block is $\sigma_0\mathbf{S}$, which is singular on the constant-pressure mode, so an unshifted `LU` hits a zero pivot and the step fails. The cheaper members of the family are reachable entirely from the options database — for example SIMPLE:
+Because nothing is baked into the operators, the Jacobian is untouched: $\mathbf{P}_\text{mat} = \mathbf{A}_\text{mat} = \mathbf{J}$, and `-ksp_type preonly -pc_type lu -pc_factor_shift_type nonzero` remains an exact monolithic reference solve. The shift is required: the $(2,2)$ block is $\mathbf{C}$, which is singular on the constant-pressure mode, so an unshifted `LU` hits a zero pivot and the step fails. The cheaper members of the family are reachable entirely from the options database — for example SIMPLE:
 
 ```
 -pc_fieldsplit_schur_precondition selfp

--- a/fluca/include/fluca/private/physinsimpl.h
+++ b/fluca/include/fluca/private/physinsimpl.h
@@ -16,9 +16,8 @@ typedef struct {
 } PhysINS_BCAdapter;
 
 typedef struct {
-  PetscReal rho;   /* density */
-  PetscReal mu;    /* dynamic viscosity */
-  PetscReal alpha; /* constraint feedback parameter = 1/dt */
+  PetscReal rho; /* density */
+  PetscReal mu;  /* dynamic viscosity */
 
   /* Boundary conditions (one per face: left, right, down, up, back, front) */
   PhysINSBC bcs[PHYS_INS_MAX_FACES];

--- a/fluca/src/phys/impls/ins/ins.c
+++ b/fluca/src/phys/impls/ins/ins.c
@@ -83,7 +83,6 @@ PetscErrorCode PhysCreate_INS(Phys phys)
   PetscCall(PetscNew(&ins));
   ins->rho        = 1.;
   ins->mu         = 1.;
-  ins->alpha      = 0.;
   ins->dt_current = 0.;
 
   /* Initialize BCs to NONE */

--- a/fluca/src/phys/impls/ins/insops.c
+++ b/fluca/src/phys/impls/ins/insops.c
@@ -80,7 +80,7 @@ PetscErrorCode PhysINSBuildOperators_Internal(Phys phys)
   Phys_INS *ins    = (Phys_INS *)phys->data;
   DM        sol_dm = phys->sol_dm;
   PetscInt  dim    = phys->dim, d, e;
-  PetscReal mu = ins->mu, rho = ins->rho;
+  PetscReal mu     = ins->mu;
 
   PetscFunctionBegin;
   /* --- fd_laplacian[d] = sum_e d/dx_e(-mu * d(u_d)/dx_e) --- */
@@ -125,12 +125,12 @@ PetscErrorCode PhysINSBuildOperators_Internal(Phys phys)
     PetscCall(FlucaFDSetUp(ins->fd_grad_p[d]));
   }
 
-  /* --- fd_div = rho * sum_d d/dx_d(interp_d(u_d)) --- */
+  /* --- fd_div = D = D_st * T = sum_d d/dx_d(interp_d(u_d)); no rho factor --- */
   {
     FlucaFD div_comp[PHYS_INS_MAX_DIM];
 
     for (d = 0; d < dim; d++) {
-      FlucaFD interp, face_deriv, div_raw;
+      FlucaFD interp, face_deriv;
 
       /* interp_d(u_d) */
       PetscCall(FlucaFDDerivativeCreate(sol_dm, (FlucaFDDirection)d, 0, 2, DMSTAG_ELEMENT, d, face_loc[d], 0, &interp));
@@ -141,14 +141,9 @@ PetscErrorCode PhysINSBuildOperators_Internal(Phys phys)
       PetscCall(FlucaFDSetUp(face_deriv));
 
       /* d/dx_d(interp_d(u_d)) */
-      PetscCall(FlucaFDCompositionCreate(interp, face_deriv, &div_raw));
-      PetscCall(FlucaFDSetUp(div_raw));
-
-      /* rho * d/dx_d(interp_d(u_d)) */
-      PetscCall(FlucaFDScaleCreateConstant(div_raw, rho, &div_comp[d]));
+      PetscCall(FlucaFDCompositionCreate(interp, face_deriv, &div_comp[d]));
       PetscCall(FlucaFDSetUp(div_comp[d]));
 
-      PetscCall(FlucaFDDestroy(&div_raw));
       PetscCall(FlucaFDDestroy(&face_deriv));
       PetscCall(FlucaFDDestroy(&interp));
     }
@@ -160,7 +155,7 @@ PetscErrorCode PhysINSBuildOperators_Internal(Phys phys)
     for (d = 0; d < dim; d++) PetscCall(FlucaFDDestroy(&div_comp[d]));
   }
 
-  /* --- fd_pstab = sigma_0 * S(p), S(p) = sum_d [d(dp/dx_d)/dx_d - d^2p/dx_d^2] --- */
+  /* --- fd_pstab = C = (dt/rho) * S(p), S(p) = sum_d [d(dp/dx_d)/dx_d - d^2p/dx_d^2] --- */
   {
     FlucaFD pstab_dir[PHYS_INS_MAX_DIM];
     FlucaFD pstab_sum;
@@ -197,7 +192,7 @@ PetscErrorCode PhysINSBuildOperators_Internal(Phys phys)
       PetscCall(FlucaFDDestroy(&cell_grad_p));
     }
 
-    /* sigma_0 * sum_d S_d(p); sigma_0 initially 0, updated to dt by TSPreStep */
+    /* (dt/rho) * sum_d S_d(p); coefficient initially 0, updated by TSPreStep */
     PetscCall(FlucaFDSumCreate(dim, pstab_dir, &pstab_sum));
     PetscCall(FlucaFDSetUp(pstab_sum));
     PetscCall(FlucaFDScaleCreateConstant(pstab_sum, 0., &ins->fd_pstab));
@@ -360,7 +355,7 @@ PetscErrorCode PhysComputeIFunction_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
     PetscCall(VecRestoreSubVector(F, ins->is_vel, &F_vel));
   }
 
-  /* F_continuity = D(u) + sigma_0 * S(p): algebraic (DAE) incompressibility constraint.
+  /* F_continuity = D(u) + C(p): algebraic (DAE) incompressibility constraint.
      Enforced directly each stage (no d/dt transform) — this is the fractional-step
      projection expressed as a DAE, matching PETSc's TS Navier-Stokes example (ts/ex46). */
   PetscCall(VecZeroEntries(temp));
@@ -495,8 +490,10 @@ static PetscErrorCode UpdatePressureStabilizationDt_Internal(TS ts, Phys_INS *in
   PetscFunctionBegin;
   PetscCall(TSGetTimeStep(ts, &dt));
   if (dt != ins->dt_current) {
-    /* sigma_0 = dt (classical Rhie-Chow pressure-stabilization coefficient) */
-    PetscCall(FlucaFDScaleSetConstant(ins->fd_pstab, dt));
+    /* C = (dt/rho) * S, the classical Rhie-Chow coefficient. The density sits here
+       rather than in fd_div so that D is the plain divergence of the interpolated
+       velocity and D = -B holds on interior rows (see THEORY_GUIDE.md). */
+    PetscCall(FlucaFDScaleSetConstant(ins->fd_pstab, dt / ins->rho));
     ins->dt_current = dt;
   }
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/fluca/src/phys/impls/ins/insops.c
+++ b/fluca/src/phys/impls/ins/insops.c
@@ -325,7 +325,7 @@ static PetscErrorCode UpdateConvectionVelocity_Internal(Phys phys, PetscReal t, 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/* --- IFunction: implicit part (viscous + pressure + ODE-transformed continuity) --- */
+/* --- IFunction: implicit part (viscous + pressure gradient + algebraic continuity) --- */
 
 PetscErrorCode PhysComputeIFunction_INS(Phys phys, PetscReal t, Vec U, Vec U_t, Vec F)
 {
@@ -337,7 +337,9 @@ PetscErrorCode PhysComputeIFunction_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
   PetscFunctionBegin;
   PetscCall(VecZeroEntries(F));
 
-  /* F_momentum_d = fd_laplacian[d](u) + fd_grad_p[d](p) */
+  /* F_momentum_d = fd_laplacian[d](u) + fd_grad_p[d](p).
+     Convection is treated explicitly (see RHSFunction), so the implicit residual is
+     linear in (U, U_t). */
   for (d = 0; d < dim; d++) {
     PetscCall(VecZeroEntries(temp));
     PetscCall(FlucaFDApply(ins->fd_laplacian[d], t, sol_dm, sol_dm, U, temp));
@@ -358,21 +360,14 @@ PetscErrorCode PhysComputeIFunction_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
     PetscCall(VecRestoreSubVector(F, ins->is_vel, &F_vel));
   }
 
-  /* F_continuity = alpha * [D(u) + sigma_0 * S(p)] + [D(du/dt) + sigma_0 * S(dp/dt)]
-     with alpha = 1 (not 1/dt) so that alpha * sigma_0 = dt, avoiding the O(1) pressure error
-     from the alpha * sigma_0 = 1 cancellation. */
+  /* F_continuity = D(u) + sigma_0 * S(p): algebraic (DAE) incompressibility constraint.
+     Enforced directly each stage (no d/dt transform) — this is the fractional-step
+     projection expressed as a DAE, matching PETSc's TS Navier-Stokes example (ts/ex46). */
   PetscCall(VecZeroEntries(temp));
   PetscCall(FlucaFDApply(ins->fd_div, t, sol_dm, sol_dm, U, temp));
-  PetscCall(VecAXPY(F, ins->alpha, temp));
-  PetscCall(VecZeroEntries(temp));
-  PetscCall(FlucaFDApply(ins->fd_pstab, t, sol_dm, sol_dm, U, temp));
-  PetscCall(VecAXPY(F, ins->alpha, temp));
-
-  PetscCall(VecZeroEntries(temp));
-  PetscCall(FlucaFDApplyDot(ins->fd_div, t, sol_dm, sol_dm, U_t, temp));
   PetscCall(VecAXPY(F, 1., temp));
   PetscCall(VecZeroEntries(temp));
-  PetscCall(FlucaFDApplyDot(ins->fd_pstab, t, sol_dm, sol_dm, U_t, temp));
+  PetscCall(FlucaFDApply(ins->fd_pstab, t, sol_dm, sol_dm, U, temp));
   PetscCall(VecAXPY(F, 1., temp));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -388,14 +383,14 @@ PetscErrorCode PhysComputeIJacobian_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
   PetscFunctionBegin;
   PetscCall(MatZeroEntries(Pmat));
 
-  /* Velocity rows: fd_laplacian[d] + fd_grad_p[d] (output_c = d < dim) */
+  /* Velocity rows: fd_laplacian[d] + fd_grad_p[d] (convection is explicit, in RHSFunction) */
   for (d = 0; d < dim; d++) {
     PetscCall(FlucaFDGetOperator(ins->fd_laplacian[d], sol_dm, sol_dm, Pmat));
     PetscCall(FlucaFDGetOperator(ins->fd_grad_p[d], sol_dm, sol_dm, Pmat));
   }
 
   /* Continuity rows: fd_div + fd_pstab (output_c = dim, no overlap with velocity rows).
-     Scaled by (shift + alpha) from alpha*C(U) + dC/dt(U_t) linearization. */
+     Algebraic constraint: coefficient 1, no shift (pressure carries no time derivative). */
   PetscCall(FlucaFDGetOperator(ins->fd_div, sol_dm, sol_dm, Pmat));
   PetscCall(FlucaFDGetOperator(ins->fd_pstab, sol_dm, sol_dm, Pmat));
 
@@ -419,20 +414,6 @@ PetscErrorCode PhysComputeIJacobian_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
     PetscCall(VecDestroy(&diag_shift));
   }
 
-  /* Continuity rows *= (shift + alpha) */
-  {
-    Vec diag_scale;
-    PetscCall(MatCreateVecs(Pmat, NULL, &diag_scale));
-    PetscCall(VecSet(diag_scale, 1.));
-    {
-      Vec subvec;
-      PetscCall(VecGetSubVector(diag_scale, ins->is_p, &subvec));
-      PetscCall(VecSet(subvec, shift + ins->alpha));
-      PetscCall(VecRestoreSubVector(diag_scale, ins->is_p, &subvec));
-    }
-    PetscCall(MatDiagonalScale(Pmat, diag_scale, NULL));
-    PetscCall(VecDestroy(&diag_scale));
-  }
   if (Amat != Pmat) {
     PetscCall(MatAssemblyBegin(Amat, MAT_FINAL_ASSEMBLY));
     PetscCall(MatAssemblyEnd(Amat, MAT_FINAL_ASSEMBLY));
@@ -452,17 +433,17 @@ PetscErrorCode PhysComputeRHSFunction_INS(Phys phys, PetscReal t, Vec U, Vec G)
   PetscFunctionBegin;
   PetscCall(VecZeroEntries(G));
 
-  /* Update convection operators with current velocity */
+  /* Update convection operators (mass flux + TVD) with the current velocity */
   PetscCall(UpdateConvectionVelocity_Internal(phys, t, U));
 
-  /* G_momentum_d = -fd_conv[d](u) */
+  /* G_momentum_d = -fd_conv[d](u) (convection treated explicitly) */
   for (d = 0; d < dim; d++) {
     PetscCall(VecZeroEntries(temp));
     PetscCall(FlucaFDApply(ins->fd_conv[d], t, sol_dm, sol_dm, U, temp));
     PetscCall(VecAXPY(G, -1., temp));
   }
 
-  /* G_momentum_d += f_d(t) */
+  /* G_momentum_d += f_d(t) (body force) */
   if (phys->bodyforce) {
     const PetscScalar **arrc[3] = {NULL, NULL, NULL};
     PetscInt            xs, ys, zs, xm, ym, zm, slot_elem;
@@ -514,8 +495,8 @@ static PetscErrorCode UpdatePressureStabilizationDt_Internal(TS ts, Phys_INS *in
   PetscFunctionBegin;
   PetscCall(TSGetTimeStep(ts, &dt));
   if (dt != ins->dt_current) {
+    /* sigma_0 = dt (classical Rhie-Chow pressure-stabilization coefficient) */
     PetscCall(FlucaFDScaleSetConstant(ins->fd_pstab, dt));
-    ins->alpha      = 1. / dt;
     ins->dt_current = dt;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -639,65 +620,35 @@ PetscErrorCode PhysSetUpTS_INS(Phys phys, TS ts)
   PetscCall(TSSetIJacobian(ts, ins->J, ins->J, IJacobian_INS, phys));
   PetscCall(TSSetRHSFunction(ts, NULL, RHSFunction_INS, phys));
 
-  /* Default to TSARKIMEX */
+  /* Default to TSARKIMEX (IMEX): convection is the explicit part, and the viscous +
+     pressure + algebraic-continuity terms are the implicit part. The default ARKIMEX
+     scheme is stiffly accurate, which integrates the algebraic pressure constraint of
+     the DAE cleanly. */
   PetscCall(TSSetType(ts, TSARKIMEX));
 
-  /* Default solver: KSPONLY + nested fieldsplit.
-     Outer: velocity (u,v,[w]) vs pressure (p).
-     Inner: additive fieldsplit on velocity — u, v, [w] independently
-     (the implicit operator has no cross terms between velocity components). */
+  /* The implicit residual is linear in (U, U_t), so each implicit stage is a single
+     linear solve — use KSPONLY (no Newton iteration needed). */
   {
-    SNES        snes;
-    KSP         ksp, *outer_sub;
-    PC          pc, vel_pc;
-    PetscInt    dim          = phys->dim, n_splits, n_vel, n_cells;
-    const char *comp_names[] = {"u", "v", "w"};
+    SNES snes;
+    KSP  ksp;
+    PC   pc;
 
     PetscCall(TSGetSNES(ts, &snes));
     PetscCall(SNESSetType(snes, SNESKSPONLY));
     PetscCall(SNESGetKSP(snes, &ksp));
     PetscCall(KSPGetPC(ksp, &pc));
+
+    /* Default linear solver: PCFIELDSPLIT with a Schur complement between velocity and
+       pressure. This is the fractional-step projection expressed as a preconditioner:
+       the velocity block solve is the momentum predictor/corrector and the pressure
+       Schur solve is the pressure-Poisson step. Sub-solver details are left to the
+       options database (see ts/ex46). The pressure null space composed onto is_p in
+       PhysINSCreateSolverData_Internal propagates to the Schur complement. */
     PetscCall(PCSetType(pc, PCFIELDSPLIT));
     PetscCall(PCFieldSplitSetIS(pc, "velocity", ins->is_vel));
     PetscCall(PCFieldSplitSetIS(pc, "pressure", ins->is_p));
-
-    /* Inner split: u, v, [w] within the velocity sub-block.
-       DMStagCreateISFromStencils orders indices by (location, component) per cell,
-       so the velocity sub-block interleaves components: [u0,v0, u1,v1, ...].
-       Each component d occupies stride positions: start=d, step=dim, count=n_cells. */
-    PetscCall(ISGetLocalSize(ins->is_vel, &n_vel));
-    n_cells = n_vel / dim;
-
-    PetscCall(PCFieldSplitGetSubKSP(pc, &n_splits, &outer_sub));
-
-    /* Velocity sub-PC: additive fieldsplit over u, v, [w] */
-    PetscCall(KSPGetPC(outer_sub[0], &vel_pc));
-    PetscCall(PCSetType(vel_pc, PCFIELDSPLIT));
-    for (PetscInt d = 0; d < dim; d++) {
-      IS is_d;
-
-      PetscCall(ISCreateStride(PetscObjectComm((PetscObject)phys), n_cells, d, dim, &is_d));
-      PetscCall(PCFieldSplitSetIS(vel_pc, comp_names[d], is_d));
-      PetscCall(ISDestroy(&is_d));
-    }
-
-    /* Default leaf-level sub-PCs to Jacobi (ILU fails on periodic grids) */
-    {
-      PetscInt n_vel_splits;
-      KSP     *vel_sub;
-      PC       sub_pc;
-
-      PetscCall(PCFieldSplitGetSubKSP(vel_pc, &n_vel_splits, &vel_sub));
-      for (PetscInt d = 0; d < n_vel_splits; d++) {
-        PetscCall(KSPGetPC(vel_sub[d], &sub_pc));
-        PetscCall(PCSetType(sub_pc, PCJACOBI));
-      }
-      PetscCall(PetscFree(vel_sub));
-
-      PetscCall(KSPGetPC(outer_sub[1], &sub_pc));
-      PetscCall(PCSetType(sub_pc, PCJACOBI));
-    }
-    PetscCall(PetscFree(outer_sub));
+    PetscCall(PCFieldSplitSetType(pc, PC_COMPOSITE_SCHUR));
+    PetscCall(PCFieldSplitSetSchurFactType(pc, PC_FIELDSPLIT_SCHUR_FACT_FULL));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/fluca/src/phys/impls/ins/insops.c
+++ b/fluca/src/phys/impls/ins/insops.c
@@ -356,8 +356,8 @@ PetscErrorCode PhysComputeIFunction_INS(Phys phys, PetscReal t, Vec U, Vec U_t, 
   }
 
   /* F_continuity = D(u) + C(p): algebraic (DAE) incompressibility constraint.
-     Enforced directly each stage (no d/dt transform) — this is the fractional-step
-     projection expressed as a DAE, matching PETSc's TS Navier-Stokes example (ts/ex46). */
+     Enforced directly each stage (no d/dt transform), so the pressure is an algebraic
+     variable, matching PETSc's TS Navier-Stokes example (ts/ex46). */
   PetscCall(VecZeroEntries(temp));
   PetscCall(FlucaFDApply(ins->fd_div, t, sol_dm, sol_dm, U, temp));
   PetscCall(VecAXPY(F, 1., temp));
@@ -636,7 +636,7 @@ PetscErrorCode PhysSetUpTS_INS(Phys phys, TS ts)
     PetscCall(KSPGetPC(ksp, &pc));
 
     /* Default linear solver: PCFIELDSPLIT with a Schur complement between velocity and
-       pressure. This is the fractional-step projection expressed as a preconditioner:
+       pressure. This is the pressure-velocity decoupling expressed as a preconditioner:
        the velocity block solve is the momentum predictor/corrector and the pressure
        Schur solve is the pressure-Poisson step. Sub-solver details are left to the
        options database (see ts/ex46). The pressure null space composed onto is_p in

--- a/fluca/tests/phys/CMakeLists.txt
+++ b/fluca/tests/phys/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SRCS
     ex1.c
     ex2.c
     ex3.c
+    ex4.c
 )
 
 foreach(test_src ${TEST_SRCS})

--- a/fluca/tests/phys/ex4.c
+++ b/fluca/tests/phys/ex4.c
@@ -1,0 +1,144 @@
+#include <flucaphys.h>
+#include <flucasys.h>
+#include <petscdmstag.h>
+
+static const char help[] = "Test that the discrete gradient and divergence blocks are negative\n"
+                           "transposes on interior rows: D = -B, where B^T is the (0,1) block and\n"
+                           "D the (1,0) block of the Jacobian. This is discrete integration by\n"
+                           "parts; it pins the density out of D, so it fails if the divergence\n"
+                           "operator carries a rho factor. Only interior rows are compared: on\n"
+                           "boundary rows the velocity Dirichlet conditions imposed on D and the\n"
+                           "pressure Neumann conditions imposed on B^T are not adjoint.\n"
+                           "Options:\n"
+                           "  -stag_grid_x <int>, -stag_grid_y <int> : Grid cells per direction\n"
+                           "  -stag_boundary_type_x/y <type>         : periodic leaves no boundary rows\n"
+                           "  -phys_ins_density <real>               : Density; use a non-unit value\n";
+
+static PetscErrorCode BCVelocityZero(PetscInt dim, PetscReal t, const PetscReal x[], PetscInt comp, PetscScalar *val, void *ctx)
+{
+  PetscFunctionBeginUser;
+  *val = 0.;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **argv)
+{
+  DM             dm, sol_dm;
+  Phys           phys;
+  Mat            J, Gblk, Dblk, DblkT;
+  Vec            Y, Ydot;
+  IS             is_vel, is_p;
+  PhysINSBC      bc;
+  DMBoundaryType bndx, bndy;
+  PetscBool      periodic;
+  PetscInt       dim = 2, Nx, Ny, e, c, f, n, nv, np, *vi, *pi;
+  PetscReal      nrm_g, nrm_diff;
+
+  PetscFunctionBeginUser;
+  PetscCall(FlucaInitialize(&argc, &argv, NULL, help));
+
+  PetscCall(DMStagCreate2d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, DM_BOUNDARY_NONE, 8, 8, PETSC_DECIDE, PETSC_DECIDE, 0, 0, 1, DMSTAG_STENCIL_STAR, 1, NULL, NULL, &dm));
+  PetscCall(DMSetFromOptions(dm));
+  PetscCall(DMSetUp(dm));
+  PetscCall(DMStagSetUniformCoordinatesProduct(dm, 0., 1., 0., 1., 0., 0.));
+
+  PetscCall(DMStagGetBoundaryTypes(dm, &bndx, &bndy, NULL));
+  PetscCall(DMStagGetGlobalSizes(dm, &Nx, &Ny, NULL));
+  periodic = (PetscBool)(bndx == DM_BOUNDARY_PERIODIC && bndy == DM_BOUNDARY_PERIODIC);
+  PetscCheck(periodic || (bndx != DM_BOUNDARY_PERIODIC && bndy != DM_BOUNDARY_PERIODIC), PETSC_COMM_WORLD, PETSC_ERR_SUP, "Mixed periodicity is not covered by this test");
+
+  PetscCall(PhysCreate(PETSC_COMM_WORLD, &phys));
+  PetscCall(PhysSetType(phys, PHYSINS));
+  PetscCall(PhysSetBaseDM(phys, dm));
+  if (!periodic) {
+    bc.type       = PHYS_INS_BC_VELOCITY;
+    bc.fn         = BCVelocityZero;
+    bc.ctx        = NULL;
+    bc.fn_dot     = NULL;
+    bc.fn_dot_ctx = NULL;
+    for (f = 0; f < 2 * dim; f++) PetscCall(PhysINSSetBoundaryCondition(phys, f, bc));
+  }
+  PetscCall(PhysSetFromOptions(phys));
+  PetscCall(PhysSetUp(phys));
+  PetscCall(PhysGetSolutionDM(phys, &sol_dm));
+
+  /* The implicit residual is linear, so the Jacobian does not depend on the state */
+  PetscCall(DMCreateGlobalVector(sol_dm, &Y));
+  PetscCall(DMCreateGlobalVector(sol_dm, &Ydot));
+  PetscCall(VecSet(Y, 1.));
+  PetscCall(VecSet(Ydot, 1.));
+
+  /* The stabilization stencil is wider than the DM stencil width, and the velocity
+     Dirichlet stencils widen further on boundary rows, so let PETSc grow the pattern */
+  PetscCall(DMCreateMatrix(sol_dm, &J));
+  PetscCall(MatSetOption(J, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE));
+  PetscCall(PhysComputeIJacobian(phys, 0., Y, Ydot, 1., J, J));
+
+  /* Index sets for the interior elements only. Elements are numbered row-major with
+     dim + 1 contiguous DOFs each (velocity components, then pressure); this holds for
+     the single-rank runs these tests use. */
+  PetscCall(VecGetSize(Y, &n));
+  PetscCheck(n == Nx * Ny * (dim + 1), PETSC_COMM_WORLD, PETSC_ERR_PLIB, "Unexpected DOF layout");
+  PetscCall(PetscMalloc1(Nx * Ny * dim, &vi));
+  PetscCall(PetscMalloc1(Nx * Ny, &pi));
+  nv = np = 0;
+  for (e = 0; e < Nx * Ny; e++) {
+    PetscInt ix = e % Nx, iy = e / Nx;
+
+    if (!periodic && (ix == 0 || ix == Nx - 1 || iy == 0 || iy == Ny - 1)) continue;
+    for (c = 0; c < dim; c++) vi[nv++] = e * (dim + 1) + c;
+    pi[np++] = e * (dim + 1) + dim;
+  }
+  PetscCall(ISCreateGeneral(PETSC_COMM_SELF, nv, vi, PETSC_USE_POINTER, &is_vel));
+  PetscCall(ISCreateGeneral(PETSC_COMM_SELF, np, pi, PETSC_USE_POINTER, &is_p));
+
+  PetscCall(MatCreateSubMatrix(J, is_vel, is_p, MAT_INITIAL_MATRIX, &Gblk));
+  PetscCall(MatCreateSubMatrix(J, is_p, is_vel, MAT_INITIAL_MATRIX, &Dblk));
+  PetscCall(MatTranspose(Dblk, MAT_INITIAL_MATRIX, &DblkT));
+
+  /* DblkT <- B^T + D^T, which vanishes exactly when D = -B */
+  PetscCall(MatNorm(Gblk, NORM_INFINITY, &nrm_g));
+  PetscCall(MatAXPY(DblkT, 1., Gblk, DIFFERENT_NONZERO_PATTERN));
+  PetscCall(MatNorm(DblkT, NORM_INFINITY, &nrm_diff));
+
+  PetscCheck(nrm_g > 0., PETSC_COMM_WORLD, PETSC_ERR_PLIB, "Gradient block is empty; the test would pass vacuously");
+  PetscCheck(nrm_diff <= 1e-12 * nrm_g, PETSC_COMM_WORLD, PETSC_ERR_PLIB, "D != -B on interior rows: ||B^T + D^T||/||B^T|| = %g", (double)(nrm_diff / nrm_g));
+
+  PetscCall(MatDestroy(&DblkT));
+  PetscCall(MatDestroy(&Dblk));
+  PetscCall(MatDestroy(&Gblk));
+  PetscCall(ISDestroy(&is_p));
+  PetscCall(ISDestroy(&is_vel));
+  PetscCall(PetscFree(pi));
+  PetscCall(PetscFree(vi));
+  PetscCall(MatDestroy(&J));
+  PetscCall(VecDestroy(&Ydot));
+  PetscCall(VecDestroy(&Y));
+  PetscCall(PhysDestroy(&phys));
+  PetscCall(DMDestroy(&dm));
+
+  PetscCall(FlucaFinalize());
+  return 0;
+}
+
+/*TEST
+
+  test:
+    suffix: wall
+    nsize: 1
+    args: -stag_grid_x 8 -stag_grid_y 8 -phys_ins_density 2.5
+    output_file: output/empty.out
+
+  test:
+    suffix: periodic
+    nsize: 1
+    args: -stag_grid_x 8 -stag_grid_y 8 -stag_boundary_type_x periodic -stag_boundary_type_y periodic -phys_ins_density 7.3
+    output_file: output/empty.out
+
+  test:
+    suffix: wall_unit_density
+    nsize: 1
+    args: -stag_grid_x 6 -stag_grid_y 10 -phys_ins_density 1.0
+    output_file: output/empty.out
+
+TEST*/

--- a/fluca/tutorials/phys/ex1.c
+++ b/fluca/tutorials/phys/ex1.c
@@ -11,7 +11,14 @@ static const char help[] = "2D Taylor-Green vortex with TSARKIMEX\n"
                            "Options:\n"
                            "  -stag_grid_x <int>, -stag_grid_y <int> : Grid cells per direction (default: 32)\n"
                            "  -rho <real> : Density (default: 1.0)\n"
-                           "  -mu <real>  : Dynamic viscosity (default: 0.01)\n";
+                           "  -mu <real>  : Dynamic viscosity (default: 0.01)\n"
+                           "\n"
+                           "The pressure is an algebraic (DAE) variable, so use a stiffly-accurate\n"
+                           "integrator (e.g. -ts_arkimex_type 3, the default) and a saddle-point solver.\n"
+                           "Recommended solvers:\n"
+                           "  monolithic direct : -ksp_type preonly -pc_type lu -pc_factor_shift_type nonzero\n"
+                           "  Schur fieldsplit  : -fieldsplit_velocity_pc_type lu\n"
+                           "                      -fieldsplit_pressure_pc_type jacobi -fieldsplit_pressure_ksp_rtol 1e-10\n";
 
 /* Fill solution vector with exact TGV at time t */
 static PetscErrorCode FillExactSolution(DM sol_dm, PetscReal nu, PetscReal t, Vec Y)
@@ -167,7 +174,8 @@ int main(int argc, char **argv)
 
   /* Create TS and wire Phys callbacks.
      PhysSetUpTS sets DM, IFunction, IJacobian, RHSFunction, defaults to TSARKIMEX,
-     and configures PCFIELDSPLIT with velocity/pressure splitting. */
+     and configures a velocity/pressure PCFIELDSPLIT with a Schur complement
+     (the fractional-step projection). Sub-solvers come from the options database. */
   PetscCall(TSCreate(PETSC_COMM_WORLD, &ts));
   PetscCall(PhysSetUpTS(phys, ts));
   /* Defaults; override with -ts_max_time, -ts_dt, -ts_adapt_type */
@@ -200,13 +208,13 @@ int main(int argc, char **argv)
 /*TEST
 
   test:
-    suffix: l2
+    suffix: lu
     nsize: 1
-    args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_arkimex_type l2 -ts_adapt_type none
+    args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_type arkimex -ts_arkimex_type 3 -ts_adapt_type none -ksp_type preonly -pc_type lu -pc_factor_shift_type nonzero
 
   test:
-    suffix: prssp2
+    suffix: schur
     nsize: 1
-    args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_arkimex_type prssp2 -ts_adapt_type none
+    args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_type arkimex -ts_arkimex_type 3 -ts_adapt_type none -fieldsplit_velocity_ksp_type preonly -fieldsplit_velocity_pc_type lu -fieldsplit_pressure_ksp_type gmres -fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi
 
 TEST*/

--- a/fluca/tutorials/phys/ex1.c
+++ b/fluca/tutorials/phys/ex1.c
@@ -174,8 +174,8 @@ int main(int argc, char **argv)
 
   /* Create TS and wire Phys callbacks.
      PhysSetUpTS sets DM, IFunction, IJacobian, RHSFunction, defaults to TSARKIMEX,
-     and configures a velocity/pressure PCFIELDSPLIT with a Schur complement
-     (the fractional-step projection). Sub-solvers come from the options database. */
+     and configures a velocity/pressure PCFIELDSPLIT with a Schur complement.
+     Sub-solvers come from the options database. */
   PetscCall(TSCreate(PETSC_COMM_WORLD, &ts));
   PetscCall(PhysSetUpTS(phys, ts));
   /* Defaults; override with -ts_max_time, -ts_dt, -ts_adapt_type */

--- a/fluca/tutorials/phys/ex1.c
+++ b/fluca/tutorials/phys/ex1.c
@@ -217,4 +217,18 @@ int main(int argc, char **argv)
     nsize: 1
     args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_type arkimex -ts_arkimex_type 3 -ts_adapt_type none -fieldsplit_velocity_ksp_type preonly -fieldsplit_velocity_pc_type lu -fieldsplit_pressure_ksp_type gmres -fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi
 
+  # SIMPLE preconditioner. diag(A)^-1 must replace A^-1 in BOTH the Schur complement
+  # (A1: -fieldsplit_pressure_inner_ jacobi, which is what applies A1^-1 in the operator)
+  # and the velocity correction (A2: -fieldsplit_pressure_upper_ jacobi). A1 = A2 is what
+  # makes SIMPLE mass preserving; approximating the Schur complement alone would leave
+  # A2 = A and perturb continuity instead of momentum.
+  # The pressure KSP is converged tightly here, so A1 is defined by the inner solve alone;
+  # selfp only supplies the matching preconditioner matrix Sp = C - D diag(A)^-1 G, which
+  # keeps that pressure solve cheap. ainv_type diag is PETSc's default, spelled out to
+  # keep this case self-documenting.
+  test:
+    suffix: simple
+    nsize: 1
+    args: -stag_grid_x 16 -stag_grid_y 16 -ts_max_time 0.1 -ts_dt 0.01 -ts_type arkimex -ts_arkimex_type 3 -ts_adapt_type none -pc_fieldsplit_schur_precondition selfp -fieldsplit_pressure_mat_schur_complement_ainv_type diag -fieldsplit_pressure_inner_ksp_type preonly -fieldsplit_pressure_inner_pc_type jacobi -fieldsplit_pressure_upper_ksp_type preonly -fieldsplit_pressure_upper_pc_type jacobi -fieldsplit_velocity_ksp_type preonly -fieldsplit_velocity_pc_type lu -fieldsplit_pressure_ksp_type gmres -fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi
+
 TEST*/


### PR DESCRIPTION
- Enforce continuity as an algebraic DAE in the Phys INS IMEX solver
- Reach the SIMPLE preconditioner entirely from the options database, and cover it with a TGV tutorial test case
- Rewrite the theory guide on a single operator set: a unified matrix-form chapter, the coupled IMEX formulation, and Schur-complement preconditioning
- Rename operators to `S` (Schur complement), `C` (stabilization block), `B^T` (pressure gradient), `D_st` (staggered divergence); drop `sigma_0`
- Move the density out of the divergence operator into the stabilization block, so `D = -B` holds on interior rows
- Add `tests/phys/ex4` asserting `D = -B` at non-unit density, for wall and periodic boundaries
- Drop the superseded segregated-solver and fractional-step theory

🤖 Generated with [Claude Code](https://claude.com/claude-code)